### PR TITLE
Fix getc() usage

### DIFF
--- a/src/api/c/libspeechd.c
+++ b/src/api/c/libspeechd.c
@@ -106,7 +106,7 @@ char *strndup(const char *s, size_t n)
 #define BUFFER_LEN 256
 ssize_t getline(char **lineptr, size_t * n, FILE * f)
 {
-	char ch;
+	int ch;
 	size_t m = 0;
 	ssize_t buf_len = 0;
 	char *buf = NULL;

--- a/src/clients/spdsend/spdsend.c
+++ b/src/clients/spdsend/spdsend.c
@@ -39,7 +39,7 @@ const char *const SPDSEND_VERSION = "0.0.0";
 #define BUFFER_LEN 256
 ssize_t getline(char **lineptr, size_t * n, FILE * f)
 {
-	char ch;
+	int ch;
 	size_t m = 0;
 	ssize_t buf_len = 0;
 	char *buf = NULL;

--- a/src/common/spd_getline.c
+++ b/src/common/spd_getline.c
@@ -46,7 +46,7 @@
 
 ssize_t spd_getline(char **lineptr, size_t * n, FILE * f)
 {
-	char ch;
+	int ch;
 	ssize_t buf_pos = 0;
 	ssize_t needed = 2;	/* Always buf_pos + 2 (see below). */
 	size_t new_length = 0;


### PR DESCRIPTION
The getc() function returns an int.  A char variable cannot hold
all possible return values, in particular EOF.  In practice, with
EOF==-1, this idiom

        while ((ch = getc(f)) != EOF)

will fail in two ways:
* On platforms where char is an unsigned type by default (ARM, PowerPC),
  the loop condition will never be false.
* On platforms where char is signed, the loop will prematurely exit
  when a char -1 (0xFF) is read.