### PR TITLE
pulse: Set pulse client name when using paplay

### DIFF
--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -65,7 +65,7 @@ typedef struct {
 #define DEFAULT_PA_MIN_AUDIO_LENGTH 100
 
 static int pulse_log_level;
-static char const *pulse_play_cmd = "paplay";
+static char const *pulse_play_cmd = "paplay -n speech-dispatcher";
 
 #define MSG(level, arg...) \
 	if(level <= pulse_log_level){ \

--- a/src/modules/dummy.c
+++ b/src/modules/dummy.c
@@ -243,7 +243,7 @@ void _dummy_child()
 	    g_strdup("aplay  " DATADIR
 		     "/dummy-message.wav > /dev/null 2> /dev/null");
 	try3 =
-	    g_strdup("paplay " DATADIR
+	    g_strdup("paplay -n speech-dispatcher " DATADIR
 		     "/dummy-message.wav > /dev/null 2> /dev/null");
 
 	DBG("child: synth commands = |%s|%s|%s|", try1, try2, try3);


### PR DESCRIPTION
So it shows up as speech-dispatcher in pavucontrol like other speech modules
instead of "paplay".