### PR TITLE
Remove pyxdg dependency

### DIFF
--- a/src/api/python/speechd_config/config.py.in
+++ b/src/api/python/speechd_config/config.py.in
@@ -30,8 +30,6 @@ import socket
 import sys
 import time
 
-from xdg import BaseDirectory
-
 # Locale/gettext configuration
 
 locale.setlocale(locale.LC_ALL, '')
@@ -167,7 +165,16 @@ class Tests:
 
     def user_conf_dir(self):
         """Return user configuration directory"""
-        return os.path.join(BaseDirectory.xdg_config_home, "speech-dispatcher")
+        config_dir = os.environ['XDG_CONFIG_HOME']
+        if not config_dir:
+            home_dir = os.environ['HOME']
+            if home_dir:
+                config_dir = os.path.join(home_dir, ".config")
+            else:
+                tmpdir = os.environ['TMPDIR'] or "/tmp/"
+                config_dir = os.path.join(tmpdir, os.getlogin(), ".config")
+
+        return os.path.join(config_dir, "speech-dispatcher")
 
     def system_conf_dir(self):
         """Determine system configuration directory"""


### PR DESCRIPTION
And use the same algorithm as GLib to determine the base user config
directory (XDG_CONFIG_HOME, then ~/.config then /tmp/$USERNAME/.config)