### PR TITLE
espeak-*mbrola-generic: do not mentioned using espeak-generic

### DIFF
--- a/config/modules/espeak-mbrola-generic.conf
+++ b/config/modules/espeak-mbrola-generic.conf
@@ -70,8 +70,7 @@ GenericLanguage		  "tr" "tr" "utf-8"
 # each language and symbolic voice name. All the voices you want
 # to use must be specified here. This list will likely not be
 # up-to-date, please check eSpeak documentation and add the voices
-# you want to use. Or better use the native espeak module ('espeak'
-# not 'espeak-generic')
+# you want to use.
 
 AddVoice        "af"    "MALE1"       	"af1"
 

--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -70,9 +70,8 @@ GenericLanguage		  "tr" "tr" "utf-8"
 # AddVoice specifies which $VOICE string should be assigned to
 # each language and symbolic voice name. All the voices you want
 # to use must be specified here. This list will likely not be
-# up-to-date, please check eSpeak documentation and add the voices
-# you want to use. Or better use the native espeak module ('espeak'
-# not 'espeak-generic')
+# up-to-date, please check eSpeak NG documentation and add the voices
+# you want to use.
 
 AddVoice        "af"    "MALE1"       	"af1"
 


### PR DESCRIPTION
That was a leftover from the copy/paste from the espeak configuration.