### PR TITLE
Do not detect modules if there is just one AddModule directive

### DIFF
--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -696,7 +696,7 @@ static gboolean speechd_load_configuration(gpointer user_data)
 
 		/* We need to load modules here, since this is called both by speechd_init
 		 * and to handle SIGHUP. */
-		if (module_number_of_requested_modules() < 2) {
+		if (module_number_of_requested_modules() < 1) {
 			detected_modules = detect_output_modules(SpeechdOptions.module_dir);
 			while (detected_modules != NULL) {
 				char **parameters = detected_modules->data;


### PR DESCRIPTION
3c477293b ("only load all modules if there are no AddModule directive")
was meant to do that, but was off by one.