### PR TITLE
Detect generic configuration files

### DIFF
--- a/doc/speech-dispatcher.texi
+++ b/doc/speech-dispatcher.texi
@@ -426,10 +426,6 @@ is not contained here, please add it. Check if @code{GenericExecuteString}
 contains the correct name of your mbrola binary and correct path to its voice
 database.
 
-Uncomment the @code{AddModule} line for @code{espeak-ng-mbrola-generic} (resp.
-@code{espeak-mbrola-generic}) in @file{speechd.conf} in your configuration for
-Speech Dispatcher.
-
 Restart speech-dispatcher and in your client, select
 @code{espeak-ng-mbrola-generic} (resp. @code{espeak-mbrola-generic}) as your
 output module, or test it with the following command

--- a/src/server/module.h
+++ b/src/server/module.h
@@ -41,7 +41,7 @@ typedef struct {
 	int working;
 } OutputModule;
 
-GList *detect_output_modules(char *dirname);
+GList *detect_output_modules(const char *modules_dirname, const char *config_dirname);
 OutputModule *load_output_module(char *mod_name, char *mod_prog,
 				 char *mod_cfgfile, char *mod_dbgfile);
 int unload_output_module(OutputModule * module);

--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -697,7 +697,8 @@ static gboolean speechd_load_configuration(gpointer user_data)
 		/* We need to load modules here, since this is called both by speechd_init
 		 * and to handle SIGHUP. */
 		if (module_number_of_requested_modules() < 1) {
-			detected_modules = detect_output_modules(SpeechdOptions.module_dir);
+			detected_modules = detect_output_modules(SpeechdOptions.module_dir,
+								 SpeechdOptions.conf_dir);
 			while (detected_modules != NULL) {
 				char **parameters = detected_modules->data;
 				module_add_load_request(parameters[0],


### PR DESCRIPTION
So that all something-generic output modules are available without
having to modify the main configuration file.

Fixes #41.