### PR TITLE
Convert old #ifdefs for Solaris into autoconf checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,8 +73,8 @@ AC_TYPE_UINT32_T
 AC_FUNC_FORK
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([daemon dup2 gethostbyname gettimeofday memmove memset mkdir])
-AC_CHECK_FUNCS([select socket strcasecmp strcasestr strchr strcspn strdup])
+AC_CHECK_FUNCS([daemon dup2 gethostbyname getline gettimeofday memmove memset])
+AC_CHECK_FUNCS([mkdir select socket strcasecmp strcasestr strchr strcspn strdup])
 AC_CHECK_FUNCS([strerror strncasecmp strndup strstr strtol])
 
 # Extra libraries for sockets and espeak added by Willie Walker

--- a/configure.ac
+++ b/configure.ac
@@ -74,7 +74,7 @@ AC_FUNC_FORK
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([daemon dup2 gethostbyname gettimeofday memmove memset mkdir])
-AC_CHECK_FUNCS([select socket strcasecmp strchr strcspn strdup])
+AC_CHECK_FUNCS([select socket strcasecmp strcasestr strchr strcspn strdup])
 AC_CHECK_FUNCS([strerror strncasecmp strndup strstr strtol])
 
 # Extra libraries for sockets and espeak added by Willie Walker

--- a/configure.ac
+++ b/configure.ac
@@ -78,16 +78,22 @@ AC_CHECK_FUNCS([mkdir select socket strcasecmp strcasestr strchr strcspn strdup]
 AC_CHECK_FUNCS([strerror strncasecmp strndup strstr strtol])
 
 # Extra libraries for sockets and espeak added by Willie Walker
-# based upon how SunStudio libraries work.  Also
-# conditionally set other compiler/linker flags.
+# based upon how SunStudio compilers and Solaris libraries work.
+# Also conditionally set other compiler/linker flags.
 #
+
+# SVR4, including Solaris before 11.4, hides these in libraries other than libc
+AC_CHECK_LIB([c], [socket], [],
+	[AC_CHECK_LIB([socket], [socket], [EXTRA_SOCKET_LIBS="-lsocket"])])
+AC_CHECK_LIB([c], [gethostbyname], [],
+	[AC_CHECK_LIB([nsl], [gethostbyname],
+		[EXTRA_SOCKET_LIBS="${EXTRA_SOCKET_LIBS} -lnsl"])])
+
 if test "$GCC" = yes; then
-	EXTRA_SOCKET_LIBS=""
 	ERROR_CFLAGS="-Wall"
 	RDYNAMIC="-rdynamic"
 else
 	EXTRA_ESPEAK_LIBS="-lCstd -lCrun"
-	EXTRA_SOCKET_LIBS="-lsocket -lnsl"
 	ERROR_CFLAGS="-errwarn=%all -errtags=yes -erroff=E_STATEMENT_NOT_REACHED"
 	RDYNAMIC=""
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -58,8 +58,8 @@ AC_SUBST([SNDFILE_LIBS])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h langinfo.h limits.h netdb.h])
-AC_CHECK_HEADERS([ netinet/in.h stddef.h stdlib.h string.h sys/ioctl.h])
-AC_CHECK_HEADERS([sys/socket.h sys/time.h unistd.h wchar.h wctype.h])
+AC_CHECK_HEADERS([netinet/in.h stddef.h stdlib.h string.h sys/filio.h])
+AC_CHECK_HEADERS([sys/ioctl.h sys/socket.h sys/time.h unistd.h wchar.h wctype.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL

--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ AC_TYPE_UINT32_T
 AC_FUNC_FORK
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([dup2 gethostbyname gettimeofday memmove memset mkdir])
+AC_CHECK_FUNCS([daemon dup2 gethostbyname gettimeofday memmove memset mkdir])
 AC_CHECK_FUNCS([select socket strcasecmp strchr strcspn strdup])
 AC_CHECK_FUNCS([strerror strncasecmp strndup strstr strtol])
 

--- a/src/api/c/libspeechd.c
+++ b/src/api/c/libspeechd.c
@@ -82,8 +82,12 @@ const int range_high = 100;
 
 pthread_mutex_t spd_logging_mutex;
 
-#if !(defined(__GLIBC__) && defined(_GNU_SOURCE))
-/* Added by Willie Walker - strndup and getline are gcc-isms */
+/*
+ * Added by Willie Walker - strndup and getline were GNU libc extensions
+ * that were adopted in the POSIX.1-2008 standard, but are not yet found
+ * on all systems.
+ */
+#ifndef HAVE_STRNDUP
 char *strndup(const char *s, size_t n)
 {
 	size_t nAvail;
@@ -102,7 +106,9 @@ char *strndup(const char *s, size_t n)
 
 	return p;
 }
+#endif /* HAVE_STRNDUP */
 
+#ifndef HAVE_GETLINE
 #define BUFFER_LEN 256
 ssize_t getline(char **lineptr, size_t * n, FILE * f)
 {
@@ -143,7 +149,7 @@ ssize_t getline(char **lineptr, size_t * n, FILE * f)
 		return m;
 	}
 }
-#endif /* !(defined(__GLIBC__) && defined(_GNU_SOURCE)) */
+#endif /* HAVE_GETLINE */
 
 /* --------------------- Public functions ------------------------- */
 

--- a/src/clients/spdsend/server.c
+++ b/src/clients/spdsend/server.c
@@ -48,9 +48,10 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#if !(defined(__GLIBC__) && defined(_GNU_SOURCE))
-/* Added by Willie Walker - TEMP_FAILURE_RETRY, strndup, and getline
- * are gcc-isms
+#ifndef HAVE_GETLINE
+/*
+ * Added by Willie Walker - getline was a GNU libc extension, later adopted
+ * in the POSIX.1-2008 standard, but not yet found on all systems.
  */
 ssize_t getline(char **lineptr, size_t * n, FILE * f);
 #endif

--- a/src/clients/spdsend/spdsend.c
+++ b/src/clients/spdsend/spdsend.c
@@ -34,8 +34,11 @@
 
 const char *const SPDSEND_VERSION = "0.0.0";
 
-#if !(defined(__GLIBC__) && defined(_GNU_SOURCE))
-/* Added by Willie Walker - getline is a gcc-ism */
+#ifndef HAVE_GETLINE
+/*
+ * Added by Willie Walker - getline was a GNU libc extension, later adopted
+ * in the POSIX.1-2008 standard, but not yet found on all systems.
+ */
 #define BUFFER_LEN 256
 ssize_t getline(char **lineptr, size_t * n, FILE * f)
 {
@@ -73,7 +76,7 @@ ssize_t getline(char **lineptr, size_t * n, FILE * f)
 		return m;
 	}
 }
-#endif /* !(defined(__GLIBC__) && defined(_GNU_SOURCE)) */
+#endif /* HAVE_GETLINE */
 
 static void usage(const char *const message)
 {

--- a/src/server/output.c
+++ b/src/server/output.c
@@ -31,8 +31,10 @@
 #include "output.h"
 #include "parse.h"
 
-#if !(defined(__GLIBC__) && defined(_GNU_SOURCE))
-/* Added by Willie Walker - strndup is a gcc-ism
+#ifndef HAVE_STRNDUP
+/*
+ * Added by Willie Walker - strndup was a GNU libc extension, later adopted
+ * in the POSIX.1-2008 standard, but not yet found on all systems.
  */
 char *strndup(const char *s, size_t n)
 {
@@ -52,7 +54,7 @@ char *strndup(const char *s, size_t n)
 
 	return p;
 }
-#endif /* !(defined(__GLIBC__) && defined(_GNU_SOURCE)) */
+#endif /* HAVE_STRNDUP */
 
 void output_set_speaking_monitor(TSpeechDMessage * msg, OutputModule * output)
 {

--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -82,8 +82,8 @@ static gboolean client_process_incoming (gint          fd,
 
 void check_client_count(void);
 
-#ifdef __SUNPRO_C
-/* Added by Willie Walker - daemon is a gcc-ism
+#ifndef HAVE_DAEMON
+/* Added by Willie Walker - daemon is a common, but not universal, extension.
  */
 static int daemon(int nochdir, int noclose)
 {
@@ -118,7 +118,7 @@ static int daemon(int nochdir, int noclose)
 	}
 	return 0;
 }
-#endif /* __SUNPRO_C */
+#endif /* HAVE_DAEMON */
 
 /* --- DEBUGGING --- */
 

--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -32,6 +32,10 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+#ifdef HAVE_SYS_FILIO_H
+#include <sys/filio.h>	/* Needed for FIONREAD on Solaris */
+#endif
+
 #include "speechd.h"
 
 /* Declare dotconf functions and data structures*/
@@ -81,7 +85,6 @@ void check_client_count(void);
 #ifdef __SUNPRO_C
 /* Added by Willie Walker - daemon is a gcc-ism
  */
-#include <sys/filio.h>
 static int daemon(int nochdir, int noclose)
 {
 	int fd, i;

--- a/src/tests/run_test.c
+++ b/src/tests/run_test.c
@@ -43,8 +43,8 @@
 
 int sockk;
 
-#ifdef __SUNPRO_C
-/* Added by Willie Walker - strcasestr is a gcc-ism
+#ifndef HAVE_STRCASESTR
+/* Added by Willie Walker - strcasestr is a common but non-standard extension
  */
 char *strcasestr(const char *a, const char *b)
 {
@@ -57,7 +57,7 @@ char *strcasestr(const char *a, const char *b)
 			return (a + l);
 	return NULL;
 }
-#endif /* __SUNPRO_C */
+#endif /* HAVE_STRCASESTR */
 
 char *send_data(int fd, char *message, int wfr)
 {


### PR DESCRIPTION
Years ago, Willie Walker contributed fixes for building on Solaris 10 using #ifdef checks for the Solaris compilers and GNU libc.

This pull request converts these to autoconf checks so that you can build on Solaris with either gcc or Solaris compilers, and so that when building on current Solaris releases you don't redefine functions that Solaris 10 did not have but Solaris 11 now does.  (It should also improve portability to other non-Linux systems.)

The -lsocket -lnsl checks could be simplified by using AC_SEARCH_LIBS, as is done in https://gitlab.freedesktop.org/xorg/lib/libxtrans/blob/master/xtrans.m4#L28-30 - but then the results would just be in $LIBS, not split out into $EXTRA_SOCKET_LIBS as was done before, so
I didn't do that.