### PR TITLE
espeak-ng-mbrola-generic: propose alternative command line

### DIFF
--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -19,6 +19,12 @@
 # The command can be split into more lines, if necessary, using '\'.
 GenericExecuteSynth \
 "echo \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -q --stdin --pho | mbrola -v $VOLUME -e /usr/share/mbrola/$VOICE/$VOICE - -.au | $PLAY_COMMAND"
+# Alternatively you can shorten the command like below, which makes it
+# work directly with any audio playback utility, but then you won't
+# be able to change the volume from the client application:
+# GenericExecuteSynth \
+# "echo \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -stdin"
+
 
 # The following three items control punctuation levels None, Some, and All.
 # Each of these values will be substituted into the $PUNCT variable depending


### PR DESCRIPTION
which just lets espeak-ng output audio.

Its advantage is to be audio output agnostic, which helps e.g. when using
libao as libao.c does not set PLAY_COMMAND (as it can speak to other audio
apps).

This is not the default, though, as this prevents to set the sound
volume from the client. Which is not that useful IMHO, but I can be
wrong.