### PR TITLE
generic: Allow actually setting the synthesis voice

### DIFF
--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -64,6 +64,7 @@ void generic_set_rate(signed int rate);
 void generic_set_pitch(signed int pitch);
 void generic_set_pitch_range(signed int pitch_range);
 void generic_set_voice(SPDVoiceType voice);
+void generic_set_synthesis_voice(char *name);
 void generic_set_language(char *language);
 void generic_set_volume(signed int volume);
 void generic_set_punct(SPDPunctuation punct);
@@ -195,7 +196,7 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 		DBG("Speaking when requested to write");
 		return 0;
 	}
-
+	UPDATE_STRING_PARAMETER(voice.name, generic_set_synthesis_voice);
 	UPDATE_STRING_PARAMETER(voice.language, generic_set_language);
 	UPDATE_PARAMETER(voice_type, generic_set_voice);
 	UPDATE_PARAMETER(punctuation_mode, generic_set_punct);
@@ -665,12 +666,21 @@ void generic_set_language(char *lang)
 
 void generic_set_voice(SPDVoiceType voice)
 {
+	if (generic_msg_voice_str != NULL)
+		return;
 	assert(generic_msg_language);
 	generic_msg_voice_str =
 	    module_getvoice(generic_msg_language->code, voice);
 	if (generic_msg_voice_str == NULL) {
 		DBG("Invalid voice type specified or no voice available!");
 	}
+}
+
+void generic_set_synthesis_voice(char *name)
+{
+	assert(msg_settings.voice.name);
+	if (module_existsvoice(msg_settings.voice.name))
+		generic_msg_voice_str = msg_settings.voice.name;
 }
 
 void generic_set_punct(SPDPunctuation punct)

--- a/src/modules/module_utils.h
+++ b/src/modules/module_utils.h
@@ -407,5 +407,6 @@ int module_audio_init(char **status_info);
 	/* Prototypes from module_utils_addvoice.c */
 void module_register_settings_voices(void);
 char *module_getvoice(char *language, SPDVoiceType voice);
+gboolean module_existsvoice(char *voicename);
 
 #endif /* #ifndef __MODULE_UTILS_H */

--- a/src/modules/module_utils_addvoice.c
+++ b/src/modules/module_utils_addvoice.c
@@ -171,6 +171,15 @@ void module_register_settings_voices(void)
 						     AddVoice_cb, NULL, 0);
 }
 
+gboolean module_existsvoice(char *voicename)
+{
+	int i;
+	for (i = 0; generic_voices_list[i] != NULL; i++) {
+	if (strcasecmp(generic_voices[i].name, voicename) == 0)
+		return TRUE;
+	}
+	return FALSE;
+}
 
 SPDVoice **module_list_registered_voices(void) {
 	return (SPDVoice **)generic_voices_list;


### PR DESCRIPTION
Allow to actually set the chosen voice, for instance typing "spd-say -y
<voice>" or using the Voices->Person drop down list of Orca Preferences.