### PR TITLE
speech-dispatcher defaults to extreme low latency

### DIFF
--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -187,7 +187,7 @@ DefaultVolume 100
 
 #AudioPulseServer "default"
 
-#AudioPulseMinLength 100
+#AudioPulseMinLength 1764
 
 # -- ALSA parameters --
 

--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -63,7 +63,8 @@ typedef struct {
 
 /* This is the smallest audio sound we are expected to play immediately without buffering. */
 /* Changed to define on config file. Default is the same. */
-#define DEFAULT_PA_MIN_AUDIO_LENGTH 100
+/* Default to 20 ms of latency (1764 = 44100 * 0.020 * 2) */
+#define DEFAULT_PA_MIN_AUDIO_LENGTH 1764
 
 static int pulse_log_level;
 static char const *pulse_play_cmd = "paplay -n speech-dispatcher-generic";


### PR DESCRIPTION
speech-dispatcher requests a total latency of 1 ms, which in turn gives
sub-ms latency inside the PulseAudio engine. This causes unnecessary CPU
consumption, or underruns. I understand that you would want immediate
feedback, but 20 ms seems more reasonable.

Fixes #45