### PR TITLE
Fix taking into account bogus configuration lines

### DIFF
--- a/src/modules/module_utils.h
+++ b/src/modules/module_utils.h
@@ -246,11 +246,10 @@ configoption_t *add_config_option(configoption_t * options,
 	static char *name = NULL; \
 	DOTCONF_CB(name ## _cb) \
 	{ \
-		g_free(name); \
-		if (cmd->data.str != NULL) \
+		if (cmd->data.str != NULL) { \
+			g_free(name); \
 			name = g_strdup(cmd->data.str); \
-		else \
-			name = NULL; \
+		} \
 		return NULL; \
 	}
 


### PR DESCRIPTION
str may be NULL when the syntax is bogus in the configuration file. In
that case, better keep the default parameter than setting the option to
NULL, which may yield to segfaults in modules rather than simply the
default behavior.