### PR TITLE
module_tts_output_marks() fixes

### DIFF
--- a/src/modules/module_utils.c
+++ b/src/modules/module_utils.c
@@ -1191,10 +1191,7 @@ int module_tts_output_marks(AudioTrack track, AudioFormat format, SPDMarks *mark
 		cur.num_samples = end_sample - current_sample;
 		current_sample = end_sample;
 
-		if (!cur.num_samples)
-			continue;
-
-		if (module_tts_output(cur, format))
+		if (cur.num_samples && module_tts_output(cur, format))
 			return -1;
 		if (marks->stop)
 			return 1;


### PR DESCRIPTION
Fix detecting the marks order, and properly report all marks.

Part of #169.