### PR TITLE
Close the audio output after closing the module

### DIFF
--- a/src/modules/module_utils.c
+++ b/src/modules/module_utils.c
@@ -520,10 +520,10 @@ void do_quit(void)
 	printf("210 OK QUIT\n");
 	fflush(stdout);
 
+	module_close();
+
 	spd_audio_close(module_audio_id);
 	module_audio_id = NULL;
-
-	module_close();
 	return;
 }
 


### PR DESCRIPTION
This allows modules to still use the audio output in module_close().

This is especially important if module_stop() doesn't actually stop the playback but simply posts a stop request (which the Pulse output make awfully easy), as it allows the module to rely on the output honoring the request for normal operation, and only perform careful cleanup (including shutting down any audio remains) in module_close().

This actually fixes an intermittent crash in at least the Baratinoo module, but other modules are likely affected.

Closes #169.