### PR TITLE
Remove spurious space in string configurations

### DIFF
--- a/config/modules/espeak-mbrola-generic.conf
+++ b/config/modules/espeak-mbrola-generic.conf
@@ -26,7 +26,7 @@ GenericExecuteSynth \
 # Note that if an empty string is specified, then $PUNCT will be blank 
 # which is a default situation for espeak.
  
-GenericPunctNone " "
+GenericPunctNone ""
 GenericPunctSome "--punct=\"()[]{};:\""
 GenericPunctAll "--punct"
 

--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -32,7 +32,7 @@ GenericExecuteSynth \
 # Note that if an empty string is specified, then $PUNCT will be blank 
 # which is a default situation for espeak.
  
-GenericPunctNone " "
+GenericPunctNone ""
 GenericPunctSome "--punct=\"()[]{};:\""
 GenericPunctAll "--punct"
 

--- a/config/modules/mary-generic.conf
+++ b/config/modules/mary-generic.conf
@@ -28,7 +28,7 @@ GenericExecuteSynth \
 # Note that if an empty string is specified, then $PUNCT will be blank
 # which is a default situation for espeak.
 
-GenericPunctNone " "
+GenericPunctNone ""
 GenericPunctSome "--punct=\"()[]{};:\""
 GenericPunctAll "--punct"
 

--- a/config/modules/pico-generic.conf
+++ b/config/modules/pico-generic.conf
@@ -26,7 +26,7 @@ GenericExecuteSynth \
 # Note that if an empty string is specified, then $PUNCT will be blank 
 # which is a default situation for espeak.
  
-GenericPunctNone " "
+GenericPunctNone ""
 GenericPunctSome "--punct=\"()[]{};:\""
 GenericPunctAll "--punct"
 


### PR DESCRIPTION
They do not pose problem any more thanks to 808b9fb27484 ('Fix taking
into account bogus configuration lines').

Thanks Didier Spaier <didier@slint.fr> for spotting them!