### PR TITLE
Make copyright notices coherent in --help and --version

### DIFF
--- a/src/api/python/speechd_config/config.py.in
+++ b/src/api/python/speechd_config/config.py.in
@@ -173,11 +173,11 @@ class Tests:
         """Print version and copyright info"""
         report("spd-conf @VERSION@\n")
         report(_("""Copyright (C) %d-%d Brailcom, o.p.s.
-%s comes with ABSOLUTELY NO WARRANTY.
-You may redistribute copies of this program
-under the terms of the GNU General Public License.
-For more information about these matters, see the file named COPYING.\n""") % \
-               (2002, 2012, "spd-conf"))
+This is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version. Please see COPYING for more details.\n""") % \
+               (2002, 2012))
 
     def user_conf_dir(self):
         """Return user configuration directory"""

--- a/src/clients/say/options.c
+++ b/src/clients/say/options.c
@@ -139,13 +139,7 @@ void options_print_help(char *argv[])
 	printf(_("Print this info\n"));
 	printf("\n");
 
-	printf(_("Copyright (C) %d-%d Brailcom, o.p.s.\n"
-		 "This is free software; you can redistribute it and/or modify it\n"
-		 "under the terms of the GNU General Public License as published by\n"
-		 "the Free Software Foundation; either version 2, or (at your option)\n"
-		 "any later version. Please see COPYING for more details.\n\n"
-		 "Please report bugs to %s\n\n"), 2002, 2012,
-	       PACKAGE_BUGREPORT);
+	printf(_("Please report bugs to %s\n\n"), PACKAGE_BUGREPORT);
 
 }
 
@@ -153,11 +147,10 @@ void options_print_version()
 {
 	printf("spd-say " VERSION "\n");
 	printf(_("Copyright (C) %d-%d Brailcom, o.p.s.\n"
-		 "%s comes with ABSOLUTELY NO WARRANTY.\n"
-		 "You may redistribute copies of this program\n"
-		 "under the terms of the GNU General Public License.\n"
-		 "For more information about these matters, see the file named COPYING.\n"),
-	       2002, 2012, "spd-say");
+		 "This is free software; you can redistribute it and/or modify it\n"
+		 "under the terms of the GNU General Public License as published by\n"
+		 "the Free Software Foundation; either version 2, or (at your option)\n"
+		 "any later version. Please see COPYING for more details.\n\n"), 2002, 2012);
 }
 
 #define OPT_SET_INT(param) \

--- a/src/server/options.c
+++ b/src/server/options.c
@@ -112,26 +112,17 @@ void options_print_help(char *argv[])
 	printf("  -h, --help            ");
 	printf(_("Print this info\n"));
 	printf("\n");
-	printf(_
-	       ("Copyright (C) %d-%d Brailcom, o.p.s.\n"
-		"This is free software; you can redistribute it and/or modify it\n"
-		"under the terms of the GNU General Public License as published by\n"
-		"the Free Software Foundation; either version 2, or (at your option)\n"
-		"any later version. Please see COPYING for more details.\n\n"
-		"Please report bugs to %s\n\n"), 2002, 2012, PACKAGE_BUGREPORT);
-
+	printf(_("Please report bugs to %s\n\n"), PACKAGE_BUGREPORT);
 }
 
 void options_print_version(void)
 {
 	printf("%s %s\n", PACKAGE, VERSION);
-	printf(_
-	       ("Copyright (C) %d-%d Brailcom, o.p.s.\n"
-		"%s comes with ABSOLUTELY NO WARRANTY.\n"
-		"You may redistribute copies of this program\n"
-		"under the terms of the GNU General Public License.\n"
-		"For more information about these matters, see the file named COPYING.\n"),
-	       2002, 2012, "Speech Dispatcher");
+	printf(_("Copyright (C) %d-%d Brailcom, o.p.s.\n"
+		 "This is free software; you can redistribute it and/or modify it\n"
+		 "under the terms of the GNU General Public License as published by\n"
+		 "the Free Software Foundation; either version 2, or (at your option)\n"
+		 "any later version. Please see COPYING for more details.\n\n"), 2002, 2012);
 }
 
 #define SPD_OPTION_SET_INT(param) \


### PR DESCRIPTION
which notably fixes them in manpages.