### PR TITLE
module list: exclude dummy and generic

### DIFF
--- a/src/server/parse.c
+++ b/src/server/parse.c
@@ -921,8 +921,11 @@ char *parse_list(const char *buf, const int bytes, const int fd,
 		len = g_list_length(output_modules);
 		for (i = 0; i < len; i++) {
 			mod = g_list_nth_data(output_modules, i);
-			g_string_append_printf(result, C_OK_MODULES "-%s" NEWLINE,
-					       mod->name);
+			if (strcmp(mod->name, "dummy") &&
+			    strcmp(mod->name, "generic"))
+				g_string_append_printf(result, C_OK_MODULES
+						       "-%s" NEWLINE,
+						       mod->name);
 		}
 
 		g_string_append(result, OK_MODULES_LIST_SENT);


### PR DESCRIPTION
They are not useful for end users.