### PR TITLE
Add option to choose a later version of (L)GPL

### DIFF
--- a/src/api/guile/gssip.h
+++ b/src/api/guile/gssip.h
@@ -8,7 +8,8 @@
 
    This program is free software; you can redistribute it and/or modify it
    under the terms of the GNU Lesser General Public License as published by the Free
-   Software Foundation, version 2.1 of the License.
+   Software Foundation; either version 2.1, or (at your option) any later
+   version.
 
    This program is distributed in the hope that it will be useful, but
    WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY

--- a/src/clients/spdsend/spdsend.h
+++ b/src/clients/spdsend/spdsend.h
@@ -8,7 +8,8 @@
 
    This program is free software; you can redistribute it and/or modify it
    under the terms of the GNU General Public License as published by the Free
-   Software Foundation, version 2 of the License.
+   Software Foundation; either version 2, or (at your option) any later
+   version.
 
    This program is distributed in the hope that it will be useful, but
    WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY

--- a/src/tests/spd_cancel_long_message.c
+++ b/src/tests/spd_cancel_long_message.c
@@ -4,8 +4,9 @@
  * Copyright (C) 2010 Brailcom, o.p.s.
 *
 * This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License version 2 as
-* published by the Free Software Foundation.
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2, or (at your option)
+* any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/src/tests/spd_set_notifications_all.c
+++ b/src/tests/spd_set_notifications_all.c
@@ -4,8 +4,9 @@
  * Copyright (C) 2010 Brailcom, o.p.s.
 *
 * This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License version 2 as
-* published by the Free Software Foundation.
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2, or (at your option)
+* any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
This helps resolve possible incompatibility with software licensed
under later (L)GPL versions.

Approved by Mr Jan Buchal, director of [BRAILCOM,o.p.s.](https://brailcom.org)