### PR TITLE
build: drop spdincludedir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -464,12 +464,6 @@ AC_SUBST([spdlibdir])
 audiodir="$spdlibdir"
 AC_SUBST([audiodir])
 
-# Path for speech-dispatcher include files:
-spdincludedir=${includedir}/speech-dispatcher
-AC_SUBST([spdincludedir])
-includedir=${spdincludedir}
-AC_SUBST([includedir])
-
 # support for systemd unit files
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -19,6 +19,6 @@
 
 noinst_HEADERS = fdsetconv.h spd_utils.h i18n.h safe_io.h
 
-spdinclude_HEADERS = spd_audio_plugin.h speechd_types.h speechd_defines.h
+include_HEADERS = spd_audio_plugin.h speechd_types.h speechd_defines.h
 
 -include $(top_srcdir)/git.mk

--- a/src/api/c/Makefile.am
+++ b/src/api/c/Makefile.am
@@ -17,7 +17,7 @@
 
 ## Process this file with automake to produce Makefile.in
 
-spdinclude_HEADERS = libspeechd.h libspeechd_version.h
+include_HEADERS = libspeechd.h libspeechd_version.h
 inc_local = -I$(top_srcdir)/include/
 BUILT_SOURCES = libspeechd_version.h
 


### PR DESCRIPTION
speech-dispatcher's include strategy is such:

include/fdsetconv.h:#include <speechd_types.h>
clients/say/say.c:#include <libspeechd.h>

(sbl does the same.)

This mandates that the include file is placed at exactly
${includedir} and not any subdirectory.