### PR TITLE
speak-queue: generalize audio parameters

### DIFF
--- a/src/modules/espeak-ng.c
+++ b/src/modules/espeak-ng.c
@@ -197,7 +197,7 @@ int module_init(char **status_info)
 	espeak_voice_list = espeak_list_synthesis_voices();
 
 	/* <Threading setup */
-	ret = module_speak_queue_init(espeak_sample_rate, EspeakAudioQueueMaxSize, status_info);
+	ret = module_speak_queue_init(EspeakAudioQueueMaxSize, status_info);
 	if (ret != OK)
 		return ret;
 
@@ -607,8 +607,14 @@ static gboolean espeak_send_audio_upto(short *wav, int *sent, int upto)
 	if (wav == NULL || numsamples == 0) {
 		return TRUE;
 	}
-	short *start = wav + (*sent);
-	gboolean result = module_speak_queue_add_audio(start, numsamples);
+	AudioTrack track = {
+		.bits = 16,
+		.num_channels = 1,
+		.sample_rate = espeak_sample_rate,
+		.num_samples = numsamples,
+		.samples = wav + (*sent),
+	};
+	gboolean result = module_speak_queue_add_audio(&track, SPD_AUDIO_LE);
 	*sent = upto;
 	return result;
 }

--- a/src/modules/espeak.c
+++ b/src/modules/espeak.c
@@ -197,7 +197,7 @@ int module_init(char **status_info)
 	espeak_voice_list = espeak_list_synthesis_voices();
 
 	/* <Threading setup */
-	ret = module_speak_queue_init(espeak_sample_rate, EspeakAudioQueueMaxSize, status_info);
+	ret = module_speak_queue_init(EspeakAudioQueueMaxSize, status_info);
 	if (ret != OK)
 		return ret;
 
@@ -563,8 +563,14 @@ static gboolean espeak_send_audio_upto(short *wav, int *sent, int upto)
 	if (wav == NULL || numsamples == 0) {
 		return TRUE;
 	}
-	short *start = wav + (*sent);
-	gboolean result = module_speak_queue_add_audio(start, numsamples);
+	AudioTrack track = {
+		.bits = 16,
+		.num_channels = 1,
+		.sample_rate = espeak_sample_rate,
+		.num_samples = numsamples,
+		.samples = wav + (*sent),
+	};
+	gboolean result = module_speak_queue_add_audio(&track, SPD_AUDIO_LE);
 	*sent = upto;
 	return result;
 }

--- a/src/modules/module_utils_speak_queue.h
+++ b/src/modules/module_utils_speak_queue.h
@@ -109,9 +109,11 @@
 #include <pthread.h>
 #include <glib.h>
 
+#include "spd_audio_plugin.h"
+
 /* To be called in module_init after synth initialization, to start playback
  * threads.  */
-int module_speak_queue_init(int sample_rate, int maxsize, char **status_info);
+int module_speak_queue_init(int maxsize, char **status_info);
 
 
 /* To be called from module_speak before synthesizing the voice.  */
@@ -122,7 +124,7 @@ int module_speak_queue_before_synth(void);
 int module_speak_queue_before_play(void);
 
 /* To be called from the synth callback to push different types of events.  */
-gboolean module_speak_queue_add_audio(short *audio_chunk, int num_samples);
+gboolean module_speak_queue_add_audio(AudioTrack *track, AudioFormat format);
 gboolean module_speak_queue_add_mark(const char *markId);
 gboolean module_speak_queue_add_sound_icon(const char *filename);
 /* To be called on the last synth callback call.  */


### PR DESCRIPTION
We can simply make module_speak_queue_add_audio take an AudioTrack and
AudioFormat to avoid hardcoding anything in module_utils_speak_queue.