### PR TITLE
Update symbols importation to be ready for update to CLDR 36

### DIFF
--- a/locale/import-symbols.py
+++ b/locale/import-symbols.py
@@ -139,10 +139,16 @@ for lang,files in CLDRExceptionsList.items():
 	cldrSources = []
 	for CLDRFile in files:
 		# First add all annotations, then the derived ones.
-		cldrSources.append(path.join(annotationsDir,CLDRFile+".xml"))
-		cldrSources.append(path.join(annotationsDerivedDir,CLDRFile+".xml"))
+		if path.exists(path.join(annotationsDir,CLDRFile+".xml")):
+			cldrSources.append(path.join(annotationsDir,CLDRFile+".xml"))
+		if path.exists(path.join(annotationsDerivedDir,CLDRFile+".xml")):
+			cldrSources.append(path.join(annotationsDerivedDir,CLDRFile+".xml"))
 		processedFiles.append(CLDRFile+".xml")
-	emojiDic = createCLDRAnnotationsDict(cldrSources)
+	# We list emogies and don't continue if there is none
+	try:
+		emojiDic = createCLDRAnnotationsDict(cldrSources)
+	except AssertionError:
+		continue
 	# We write the dictionnary with the doc and the emojies
 	with codecs.open(path.join(lang, "emojis.dic"), "w", "utf_8_sig", errors="replace") as dicFile:
 		dicFile.write(docHeader)
@@ -158,8 +164,13 @@ for CLDRFile in os.listdir(annotationsDir):
 	cldrSources = []
 	# First add all annotations, then the derived ones.
 	cldrSources.append(path.join(annotationsDir,CLDRFile))
-	cldrSources.append(path.join(annotationsDerivedDir,CLDRFile))
-	emojiDic = createCLDRAnnotationsDict(cldrSources)
+	if path.exists(path.join(annotationsDerivedDir,CLDRFile)):
+		cldrSources.append(path.join(annotationsDerivedDir,CLDRFile))
+	# We list emogies and don't continue if there is none
+	try:
+		emojiDic = createCLDRAnnotationsDict(cldrSources)
+	except AssertionError:
+		continue
 	# We write the dictionnary with the doc and the emojies
 	with codecs.open(path.join(CLDRLang, "emojis.dic"), "w", "utf_8_sig", errors="replace") as dicFile:
 		dicFile.write(docHeader)


### PR DESCRIPTION
I tried to update CLDR dictionaries to version 36 which has the most added new emojis.
During the process, I encounter errors with en_GB language:
* The derived annotations file doesn't exist
* The existing one doesn't provide TTS descriptions.

So I propose to update the symbols importation script to:
* Check if all CLDR files for a language exist before processing them
* Manage the assertion error if a XML file has no processable emojis

I successfully tried to generate dictionaries with this updated script, so after that we should be able to provide version 36 for CLDR characters.