### PR TITLE
Improve locale make and add documentation for newly added dictionaries

### DIFF
--- a/locale/Makefile.am
+++ b/locale/Makefile.am
@@ -37,6 +37,7 @@ nobase_localedata_DATA = \
 	ca/emojis.dic \
 	ca/symbols.dic \
 	ccp/emojis.dic \
+	ceb/emojis.dic \
 	chr/emojis.dic \
 	ckb/symbols.dic \
 	cs/emojis.dic \
@@ -107,6 +108,7 @@ nobase_localedata_DATA = \
 	kn/symbols.dic \
 	ko/emojis.dic \
 	ko/symbols.dic \
+	kok/emojis.dic \
 	ku/emojis.dic \
 	ky/emojis.dic \
 	ky/symbols.dic \
@@ -161,6 +163,7 @@ nobase_localedata_DATA = \
 	sv/emojis.dic \
 	sv/symbols.dic \
 	sw/emojis.dic \
+	sw_KE/emojis.dic \
 	ta/emojis.dic \
 	ta/symbols.dic \
 	te/emojis.dic \

--- a/locale/Makefile.am
+++ b/locale/Makefile.am
@@ -223,3 +223,4 @@ uninstall-hook:
 	done
 
 -include $(top_srcdir)/git.mk
+GITIGNOREFILES = symbolsrc

--- a/locale/README.md
+++ b/locale/README.md
@@ -11,4 +11,7 @@
 ```
 make import-symbols
 ```
+* When some dictionaries are added, add them to the variable nobase_localedata_DATA in the file Makefile.am located in the "locale" directory.
+Use the following syntax to list the new file : `lang/file.dic \` with a tab character before.
+Please keep the alphabetical order.
 


### PR DESCRIPTION
The "symbolsrc" directory should be ignored by git as it is added manually when importing symbols and emojis dictionaries. I propose to add the directory to the GITIGNOREFILES variable in locale/Makefile.am.

I also noticed I forgot to add new emojis dictionaries to this make file in the PR importing last updated dictionaries.
To prevent avoiding this happening in the future, I suggest to add some precision about what to do when new dictionaries are imported when following instructions in locale/README.md