### PR TITLE
Use relative path when creating symbolic links for Latin American Spanish  emojis

### DIFF
--- a/locale/Makefile.am
+++ b/locale/Makefile.am
@@ -217,7 +217,7 @@ import-symbols:
 install-data-hook:
 	for lang419 in $(ES_419_CLDR) ; do \
 		$(MKDIR_P) "$(DESTDIR)$(localedatadir)/$$lang419" ;\
-		$(LN_S) "$(DESTDIR)$(localedatadir)/es_419/emojis.dic" "$(DESTDIR)$(localedatadir)/$$lang419/emojis.dic" || true ;\
+		$(LN_S) "../es_419/emojis.dic" "$(DESTDIR)$(localedatadir)/$$lang419/emojis.dic" || true ;\
 	done
 
 uninstall-hook:


### PR DESCRIPTION
When using DESTDIR Latin American Spanish languages emojis dictionaries point to the build root so making packages make broken links for these languages.
Fixes #271