### PR TITLE
Disable Mary-TTS module by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@ responsiveness parameter.
 * symbols: Add SymbolPreprocessingFile directive.
 * symbols: Import emojis and unicode font variants support from NVDA and Unicode
 CLDR and UnicodeData.
+* Disable Mary-TTS module by default.
 
 Version 0.9.1
 * Add module for the non-free IBM TTS (voxin) speech synthesis.
@@ -338,7 +339,7 @@ Version 0.0.1
 
 Copyright (C) 2002-2012 Brailcom, o.p.s
 Copyright (C) 2002-2012 Brailcom, o.p.s
-Copyright (C) 2018-2019 Samuel Thibault <samuel.thibault@ens-lyon.org>
+Copyright (C) 2018-2020 Samuel Thibault <samuel.thibault@ens-lyon.org>
 Copyright (C) 2018 Florian Steinhardt <no.known.email@example.com>
 
 This program is free software; you can redistribute it and/or modify it under

--- a/config/modules/Makefile.am
+++ b/config/modules/Makefile.am
@@ -22,14 +22,14 @@ dist_moduleconf_DATA = cicero.conf espeak.conf espeak-ng.conf festival.conf \
                        epos-generic.conf espeak-generic.conf \
                        espeak-ng-mbrola-generic.conf espeak-mbrola-generic.conf \
                        llia_phon-generic.conf \
-                       pico-generic.conf swift-generic.conf mary-generic.conf
+                       pico-generic.conf swift-generic.conf mary-generic-disabled.conf
 
 dist_moduleconforig_DATA = cicero.conf espeak.conf festival.conf espeak-ng.conf
 	                   flite.conf ibmtts.conf ivona.conf dtk-generic.conf \
                            epos-generic.conf espeak-generic.conf \
                            espeak-ng-mbrola-generic.conf espeak-mbrola-generic.conf \
                            llia_phon-generic.conf \
-                           pico-generic.conf swift-generic.conf mary-generic.conf
+                           pico-generic.conf swift-generic.conf mary-generic-disabled.conf
 
 if pico_support
 dist_moduleconf_DATA += pico.conf

--- a/config/modules/mary-generic-disabled.conf
+++ b/config/modules/mary-generic-disabled.conf
@@ -2,7 +2,8 @@
 # Dispatcher. It means there is no code written explicitly for
 # this plugin, all the specifics are handled in this configuration
 # and we call a simple command line client to perform the actual
-# synthesis. Use this config file with the sd_generic output module.
+# synthesis. To enable it, you need to rename it to mary-generic.conf, so it can
+# be used with the sd_generic output module.
 #
 # IMPORTANT: The audio output method relies on an audio playback
 # utility (play, aplay, paplay for OSS, ALSA or Pulse)


### PR DESCRIPTION
Otherwise it always prevents the dummy module from getting triggered to tell
the user that speech-dispatcher is working but no module is installed.