### PR TITLE
Update the sd_ibmtts module for compatibility with voxin 3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -230,8 +230,7 @@ AC_ARG_WITH([ibmtts],
 	[with_ibmtts=check])
 AS_IF([test $with_ibmtts != "no"],
 	[AC_CHECK_LIB([ibmeci], [eciStop],
-		[with_ibmtts=yes;
-		ibmtts_include="-I/opt/IBM/ibmtts/inc/"],
+		[with_ibmtts=yes],
 		[AS_IF([test $with_ibmtts = "yes"],
 			[AC_MSG_FAILURE([IBMTTS is not available])])
 		 with_ibmtts=shim])])
@@ -240,7 +239,6 @@ if test "$with_ibmtts" = shim -a $enable_shared = no; then
 fi
 AM_CONDITIONAL([ibmtts_support], [test $with_ibmtts != no])
 AM_CONDITIONAL([ibmtts_shim], [test $with_ibmtts = shim])
-AC_SUBST([ibmtts_include])
 AS_IF([test $with_ibmtts != no], [output_modules="${output_modules} ibmtts"])
 
 # check for ivona support

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -32,7 +32,7 @@ AM_CFLAGS = $(ERROR_CFLAGS)
 AM_CPPFLAGS = $(inc_local) -DDATADIR=\"$(snddatadir)\" -D_GNU_SOURCE \
 	-DPLUGIN_DIR="\"$(audiodir)\"" \
 	$(DOTCONF_CFLAGS) $(GLIB_CFLAGS) $(GTHREAD_CFLAGS) \
-	$(ibmtts_include) $(SNDFILE_CFLAGS)
+	$(SNDFILE_CFLAGS)
 
 modulebin_PROGRAMS = sd_dummy sd_generic sd_festival sd_cicero
 
@@ -74,8 +74,7 @@ modulebin_PROGRAMS += sd_ibmtts
 sd_ibmtts_SOURCES = ibmtts.c $(audio_SOURCES) $(common_SOURCES) \
 	module_utils_addvoice.c
 sd_ibmtts_LDADD = $(top_builddir)/src/common/libcommon.la \
-	$(audio_dlopen_modules) \
-	-libmeci \
+	$(audio_dlopen_modules) -ldl \
 	$(common_LDADD)
 
 if ibmtts_shim

--- a/src/modules/voxin.h
+++ b/src/modules/voxin.h
@@ -1,0 +1,60 @@
+/*
+  libvoxin API, v 1.4.6 copied from
+  https://raw.githubusercontent.com/Oralux/libvoxin/2ad36d8f7c07ea80663c9b3524de443abdf76758/src/api/voxin.h
+
+  Copyright: 2016-2020 Gilles Casse <gcasse@oralux.org>
+  License: LGPL-2.1+ or MIT
+ 
+*/
+#ifndef VOXIN_H
+#define VOXIN_H
+
+#include <stdint.h>
+#include "eci.h"
+
+#define LIBVOXIN_VERSION_MAJOR 1
+#define LIBVOXIN_VERSION_MINOR 4
+#define LIBVOXIN_VERSION_PATCH 6
+
+typedef enum {voxFemale, voxMale} voxGender;
+typedef enum {voxAdult, voxChild, voxSenior} voxAge;
+
+#define VOX_ECI_VOICES 22
+#define VOX_RESERVED_VOICES 30
+#define VOX_MAX_NB_OF_LANGUAGES (VOX_ECI_VOICES + VOX_RESERVED_VOICES)
+#define VOX_STR_MAX 128
+#define VOX_LAST_ECI_VOICE eciStandardFinnish
+
+typedef struct {
+  uint32_t id; // voice identifier, e.g.: 0x2d0002
+  char name[VOX_STR_MAX]; // optional: 'Yelda',...
+  char lang[VOX_STR_MAX]; // ietf sub tag, iso639-1, 2 letters code: 'en', 'tr',...
+  char variant[VOX_STR_MAX]; // ietf sub tag, optional: 'scotland', 'CA',...
+  uint32_t rate; // sample rate in Hertz: 11025, 22050
+  uint32_t  size; // sample size e.g. 16 bits
+  /* chanels = 1 */
+  /* encoding = signed-integer PCM */
+  char charset[VOX_STR_MAX]; // "UTF-8", "ISO-8859-1",...
+  voxGender gender;
+  voxAge age;
+  char multilang[VOX_STR_MAX]; // optional, e.g. "en,fr"
+  char quality[VOX_STR_MAX]; // optional, e.g. "embedded-compact"
+  uint32_t tts_id;
+} vox_t;
+
+// voxGetVoices returns the list of available languages.
+// This functions depreciates eciGetAvailableLanguages.
+// eciGetAvailableLanguages behaves identically if the installed
+// languages come from ECI.
+// Otherwise, eciGetAvailableLanguages returns an unexpected language
+// identifier.
+//
+// Return 0 if ok
+int voxGetVoices(vox_t *list, unsigned int *nbVoices);
+
+// convert the vox_t data to a string in the buffer supplied by the caller (up to len, 0 terminator included)
+// return 0 if ok
+int voxString(vox_t *v, char *s, size_t len);
+
+#endif
+


### PR DESCRIPTION
sd_ibmtts can still be built without voxin installed using the '--with-ibmtts=shim' configure option.
voxin.h is included and copied from libvoxin 1.4.6 (https://github.com/Oralux/libvoxin).
    
* Note for voxin users
The voxin installer removes sd_ibmtts and uses sd_voxin instead.
sd_voxin simply helps to select according to the version of speech-dispatcher a suitable sd_ibmtts module customized for voxin 3.0 ( https://github.com/Oralux/voxin-installer/tree/master/src/speechd-voxin )
    
* Example 
Tests using voxin 3.0 + IBM TTS (American_English) and Vocalizer Embedded (nathan-embedded-compact)

Example 1: ask the ibmtts module to list voices
Command: LC_ALL=C spd-say -o ibmtts -L
    
                         NAME                 LANGUAGE                  VARIANT
             American_English                    en-US                     none
      nathan-embedded-compact                       en                       US
    
Example 2: ask the ibmtts module to say a sentence
Command: LC_ALL=C spd-say -y nathan-embedded-compact -o ibmtts "Hello Mr Smith"
