### PR TITLE
Replace AudioPulseServer option with AudioPulseDevice

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,7 @@ responsiveness parameter.
 * symbols: Import emojis and unicode font variants support from NVDA and Unicode
 CLDR and UnicodeData.
 * Disable Mary-TTS module by default.
+* Replace AudioPulseServer option with AudioPulseDevice
 
 Version 0.9.1
 * Add module for the non-free IBM TTS (voxin) speech synthesis.

--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -189,9 +189,9 @@ SymbolPreprocFile "font-variants.dic"
 
 # -- Pulse Audio parameters --
 
-# Pulse audio server name or "default" for the default pulse server
+# Pulse audio device name or "default" for the default pulse device
 
-#AudioPulseServer "default"
+#AudioPulseDevice "default"
 
 #AudioPulseMinLength 1764
 

--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -56,6 +56,7 @@ typedef struct {
 	AudioID id;
 	pa_simple *pa_simple;
 	char *pa_server;
+	char *pa_device;
 	char *pa_name;
 	int pa_min_audio_length;
 	volatile int pa_stop_playback;
@@ -148,7 +149,7 @@ static int _pulse_open(spd_pulse_id_t * id, int sample_rate,
 	if (!
 	    (id->pa_simple =
 	     pa_simple_new(id->pa_server, client_name,
-			   PA_STREAM_PLAYBACK, NULL, "playback",
+			   PA_STREAM_PLAYBACK, id->pa_device, "playback",
 			   &ss, NULL, &buffAttr, &error))) {
 		fprintf(stderr, __FILE__ ": pa_simple_new() failed: %s\n",
 			pa_strerror(error));
@@ -184,7 +185,8 @@ static AudioID *pulse_open(void **pars)
 	pulse_id->id.format = SPD_AUDIO_LE;
 #endif
 	pulse_id->pa_simple = NULL;
-	pulse_id->pa_server = (char *)pars[3];
+	pulse_id->pa_server = NULL;
+	pulse_id->pa_device = (char *)pars[3];
 	pulse_id->pa_name = (char *)pars[5];
 	pulse_id->pa_min_audio_length = DEFAULT_PA_MIN_AUDIO_LENGTH;
 
@@ -194,6 +196,10 @@ static AudioID *pulse_open(void **pars)
 
 	if (!strcmp(pulse_id->pa_server, "default")) {
 		pulse_id->pa_server = NULL;
+	}
+
+	if (!strcmp(pulse_id->pa_device, "default")) {
+		pulse_id->pa_device = NULL;
 	}
 
 	if (pars[4] != NULL && atoi(pars[4]) != 0)

--- a/src/modules/module_utils.c
+++ b/src/modules/module_utils.c
@@ -338,7 +338,11 @@ char *do_audio(void)
 				    else
 				SET_AUDIO_STR(audio_nas_server, 3)
 				    else
+				      /* TODO: restore AudioPulseServer option
 				SET_AUDIO_STR(audio_pulse_server, 4)
+				    else
+				    */
+				SET_AUDIO_STR(audio_pulse_device, 4)
 				    else
 				SET_AUDIO_STR(audio_pulse_min_length, 5)
 				    else

--- a/src/server/alloc.c
+++ b/src/server/alloc.c
@@ -39,6 +39,7 @@ TFDSetElement spd_fdset_copy(TFDSetElement *old)
 	new.audio_alsa_device = g_strdup(old->audio_alsa_device);
 	new.audio_nas_server = g_strdup(old->audio_nas_server);
 	new.audio_pulse_server = g_strdup(old->audio_pulse_server);
+	new.audio_pulse_device = g_strdup(old->audio_pulse_device);
 
 	return new;
 
@@ -76,6 +77,7 @@ void mem_free_fdset(TFDSetElement * fdset)
 	g_free(fdset->audio_alsa_device);
 	g_free(fdset->audio_nas_server);
 	g_free(fdset->audio_pulse_server);
+	g_free(fdset->audio_pulse_device);
 }
 
 void mem_free_message(TSpeechDMessage * msg)

--- a/src/server/configuration.c
+++ b/src/server/configuration.c
@@ -185,6 +185,7 @@ GLOBAL_FDSET_OPTION_CB_STR(DefaultModule, output_module)
     GLOBAL_FDSET_OPTION_CB_STR(AudioALSADevice, audio_alsa_device)
     GLOBAL_FDSET_OPTION_CB_STR(AudioNASServer, audio_nas_server)
     GLOBAL_FDSET_OPTION_CB_STR(AudioPulseServer, audio_pulse_server)
+    GLOBAL_FDSET_OPTION_CB_STR(AudioPulseDevice, audio_pulse_device)
     GLOBAL_FDSET_OPTION_CB_INT(AudioPulseMinLength, audio_pulse_min_length, 1, "")
 
     GLOBAL_FDSET_OPTION_CB_INT(DefaultRate, msg_settings.rate, (val >= -100)
@@ -470,6 +471,7 @@ configoption_t *load_config_options(int *num_options)
 	ADD_CONFIG_OPTION(AudioALSADevice, ARG_STR);
 	ADD_CONFIG_OPTION(AudioNASServer, ARG_STR);
 	ADD_CONFIG_OPTION(AudioPulseServer, ARG_STR);
+	ADD_CONFIG_OPTION(AudioPulseDevice, ARG_STR);
 	ADD_CONFIG_OPTION(AudioPulseMinLength, ARG_INT);
 
 	ADD_CONFIG_OPTION(BeginClient, ARG_STR);
@@ -505,6 +507,7 @@ void load_default_global_set_options()
 	GlobalFDSet.audio_alsa_device = g_strdup("default");
 	GlobalFDSet.audio_nas_server = g_strdup("tcp/localhost:5450");
 	GlobalFDSet.audio_pulse_server = g_strdup("default");
+	GlobalFDSet.audio_pulse_device = g_strdup("default");
 	GlobalFDSet.audio_pulse_min_length = 100;
 
 	SpeechdOptions.max_history_messages = 10000;

--- a/src/server/output.c
+++ b/src/server/output.c
@@ -475,7 +475,9 @@ int output_send_audio_settings(OutputModule * output)
 	ADD_SET_STR(audio_oss_device);
 	ADD_SET_STR(audio_alsa_device);
 	ADD_SET_STR(audio_nas_server);
-	ADD_SET_STR(audio_pulse_server);
+	// TODO: restore AudioPulseServer option
+	//ADD_SET_STR(audio_pulse_server);
+	ADD_SET_STR(audio_pulse_device);
 	ADD_SET_INT(audio_pulse_min_length);
 
 	SEND_CMD_N("AUDIO");

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -112,6 +112,7 @@ queue_message(TSpeechDMessage * new, int fd, int history_flag,
 		COPY_SET_STR(audio_alsa_device);
 		COPY_SET_STR(audio_nas_server);
 		COPY_SET_STR(audio_pulse_server);
+		COPY_SET_STR(audio_pulse_device);
 
 		/* And we set the global id (note that this is really global, not
 		 * depending on the particular client, but unique) */

--- a/src/server/set.c
+++ b/src/server/set.c
@@ -540,6 +540,7 @@ TFDSetElement *default_fd_set(void)
 	new->audio_alsa_device = g_strdup(GlobalFDSet.audio_alsa_device);
 	new->audio_nas_server = g_strdup(GlobalFDSet.audio_nas_server);
 	new->audio_pulse_server = g_strdup(GlobalFDSet.audio_pulse_server);
+	new->audio_pulse_device = g_strdup(GlobalFDSet.audio_pulse_device);
 
 	new->msg_settings.voice_type = GlobalFDSet.msg_settings.voice_type;
 	new->msg_settings.voice.name = NULL;

--- a/src/server/speechd.h
+++ b/src/server/speechd.h
@@ -99,6 +99,7 @@ typedef struct {
 	char *audio_alsa_device;
 	char *audio_nas_server;
 	char *audio_pulse_server;
+	char *audio_pulse_device;
 	int audio_pulse_min_length;
 	int log_level;
 


### PR DESCRIPTION
Changing the pulse server is rarely useful for a user, while changing
the device definitely is. Let's keep the code for the server
configuration for now, enabling it will "just" need to break the module
parameter interface.