### PR TITLE
pico: play at least 50ms at a time

### DIFF
--- a/src/modules/pico.c
+++ b/src/modules/pico.c
@@ -43,7 +43,8 @@
 
 DECLARE_DEBUG();
 
-#define MAX_OUTBUF_SIZE		(128)
+#define MIN_OUTBUF_SIZE		(1600)
+#define MAX_OUTBUF_SIZE		(3200)
 #define PICO_MEM_SIZE			(10000000)
 
 #define PICO_VOICE_SPEED_MIN		(20)
@@ -159,6 +160,7 @@ static int pico_set_pitch(signed int value)
 static int pico_process_tts(void)
 {
 	pico_Int16 bytes_sent, bytes_recv, text_remaining, out_data_type;
+	pico_Int16 bytes_stored;
 	int ret, getstatus;
 	short outbuf[MAX_OUTBUF_SIZE];
 	pico_Retstring outMessage;
@@ -189,12 +191,15 @@ static int pico_process_tts(void)
 
 		text_remaining -= bytes_sent;
 		buf += bytes_sent;
+		bytes_stored = 0;
 
 		do {
 			/* Retrieve the samples and add them to the buffer.
 			   SVOX pico TTS sample rate is 16K */
-			getstatus = pico_getData(picoEngine, (void *)outbuf,
-						 MAX_OUTBUF_SIZE, &bytes_recv,
+			getstatus = pico_getData(picoEngine,
+						 (void *)outbuf + bytes_stored,
+						 MAX_OUTBUF_SIZE - bytes_stored,
+						 &bytes_recv,
 						 &out_data_type);
 			if ((getstatus != PICO_STEP_BUSY)
 			    && (getstatus != PICO_STEP_IDLE)) {
@@ -206,8 +211,11 @@ static int pico_process_tts(void)
 				return -1;
 			}
 
-			if (bytes_recv) {
-				track.num_samples = bytes_recv / 2;
+			bytes_stored += bytes_recv;
+
+			if (bytes_stored >= MIN_OUTBUF_SIZE
+					|| PICO_STEP_BUSY != getstatus) {
+				track.num_samples = bytes_stored / 2;
 				track.samples = outbuf;
 				track.num_channels = 1;
 				track.sample_rate = PICO_SAMPLE_RATE;
@@ -221,6 +229,7 @@ static int pico_process_tts(void)
 					    "Can't play track for unknown reason.");
 					return -1;
 				}
+				bytes_stored = 0;
 			}
 			if (g_atomic_int_get(&pico_state) != STATE_PLAY) {
 				text_remaining = 0;


### PR DESCRIPTION
By default pico would return just 2ms audio, it's a battery waste to push
only that tiny amount to audio stacks. Call pico several times to try to
get 50ms audio, but not more than 100ms so that interrupts remain
snappy.