### PR TITLE
Add CharSymbolPreprocFile directive

### DIFF
--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -151,7 +151,7 @@ DefaultVolume 100
 
 # Which preprocessing files should be loaded, and in which order
 
-SymbolPreprocFile "emojis.dic"
+CharSymbolPreprocFile "emojis.dic"
 SymbolPreprocFile "gender-neutral.dic"
 SymbolPreprocFile "font-variants.dic"
 # PunctuationSymbolPreprocFile "symbols.dic"

--- a/src/server/configuration.c
+++ b/src/server/configuration.c
@@ -316,6 +316,19 @@ DOTCONF_CB(cb_SymbolPreprocFile)
 	return NULL;
 }
 
+DOTCONF_CB(cb_CharSymbolPreprocFile)
+{
+	if (cmd->data.list[0] == NULL) {
+		MSG(3,
+		    "No char symbol preprocessing name specified in configuration under CharSymbolsPreprocFile");
+		return NULL;
+	}
+
+	symbols_char_preprocessing_add_file(cmd->data.list[0]);
+
+	return NULL;
+}
+
 DOTCONF_CB(cb_PunctuationSymbolPreprocFile)
 {
 	if (cmd->data.list[0] == NULL) {
@@ -457,6 +470,7 @@ configoption_t *load_config_options(int *num_options)
 	ADD_CONFIG_OPTION(DefaultPunctuationMode, ARG_STR);
 	ADD_CONFIG_OPTION(DefaultSymbolsPreproc, ARG_INT);
 	ADD_CONFIG_OPTION(SymbolPreprocFile, ARG_STR);
+	ADD_CONFIG_OPTION(CharSymbolPreprocFile, ARG_STR);
 	ADD_CONFIG_OPTION(PunctuationSymbolPreprocFile, ARG_STR);
 	ADD_CONFIG_OPTION(DefaultClientName, ARG_STR);
 	ADD_CONFIG_OPTION(DefaultVoiceType, ARG_STR);

--- a/src/server/symbols.h
+++ b/src/server/symbols.h
@@ -26,6 +26,9 @@
 /* Load symbols from this file */
 void symbols_preprocessing_add_file(const char *name);
 
+/* Load character symbols from this file */
+void symbols_char_preprocessing_add_file(const char *name);
+
 /* Load punctuation symbols from this file */
 void symbols_punctuation_preprocessing_add_file(const char *name);
 


### PR DESCRIPTION
We need to distinguish between symbol preprocessing that manages
character description (and thus should disable the module character
description processing) from other symbol preprocessing that shouldn't
disable character description processing.