### PR TITLE
symbols: Separate out "no" from invalid

### DIFF
--- a/src/server/symbols.c
+++ b/src/server/symbols.c
@@ -149,7 +149,7 @@ SymLvl str2SymLvl(char *str)
 	SymLvl punct;
 
 	if (!strcmp(str, "no"))
-		punct = SYMLVL_INVALID;
+		punct = SYMLVL_NO;
 	else if (!strcmp(str, "none"))
 		punct = SYMLVL_NONE;
 	else if (!strcmp(str, "all"))

--- a/src/server/symbols.h
+++ b/src/server/symbols.h
@@ -32,10 +32,11 @@ void insert_symbols(TSpeechDMessage *msg, int punct_missing);
 /* Speech symbols punctuation levels */
 typedef enum {
 	SYMLVL_INVALID = -1,
-	SYMLVL_NONE = 0,
-	SYMLVL_SOME = 100,
-	SYMLVL_MOST = 200,
-	SYMLVL_ALL = 300,
+	SYMLVL_NO = 0,
+	SYMLVL_NONE = 100,
+	SYMLVL_SOME = 200,
+	SYMLVL_MOST = 300,
+	SYMLVL_ALL = 500,
 	SYMLVL_CHAR = 1000
 } SymLvl;
 


### PR DESCRIPTION
Otherwise we cannot choose it in the configuration file since -1 is
hardcoded to be for errors.