### PR TITLE
ibmtts: Add runpath to /opt/IBM/ibmtts/lib

### DIFF
--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -80,6 +80,7 @@ sd_ibmtts_LDADD = $(top_builddir)/src/common/libcommon.la \
 
 if ibmtts_shim
 sd_ibmtts_LDADD += -L.
+sd_ibmtts_LDFLAGS = -Wl,-rpath=/opt/IBM/ibmtts/lib
 
 EXTRA_sd_ibmtts_DEPENDENCIES = libibmeci.so
 


### PR DESCRIPTION
libibmeci.so is usually installed there, so make sure we automatically
try to get it from there.