### PR TITLE
generic: Use printf instead of echo

### DIFF
--- a/config/modules/dtk-generic.conf
+++ b/config/modules/dtk-generic.conf
@@ -26,7 +26,7 @@
 # I know of to fix this is to upgrade from DECTalk 4.61 to DECTalk 5.
 GenericExecuteSynth \
 "echo \"[:n$VOICE][:ra $RATE][:dv ap $PITCH]\" >$TMPDIR/dtk-speak.txt \
-&& echo \'$DATA\' | fmt >>$TMPDIR/dtk-speak.txt && say -fi $TMPDIR/dtk-speak.txt"
+&& printf %s \'$DATA\' | fmt >>$TMPDIR/dtk-speak.txt && say -fi $TMPDIR/dtk-speak.txt"
 
 GenericCmdDependency "say"
 

--- a/config/modules/espeak-generic.conf
+++ b/config/modules/espeak-generic.conf
@@ -20,7 +20,7 @@
 # can modify this value, see other parameters).
 # The command can be split into more lines, if necessary, using '\'.
 GenericExecuteSynth \
-"echo \'$DATA\' | espeak -w $TMPDIR/espeak.wav -v $VOICE -s $RATE -a $VOLUME -p $PITCH $PUNCT --stdin && $PLAY_COMMAND $TMPDIR/espeak.wav"
+"printf %s \'$DATA\' | espeak -w $TMPDIR/espeak.wav -v $VOICE -s $RATE -a $VOLUME -p $PITCH $PUNCT --stdin && $PLAY_COMMAND $TMPDIR/espeak.wav"
 
 GenericCmdDependency "espeak"
 

--- a/config/modules/espeak-mbrola-generic.conf
+++ b/config/modules/espeak-mbrola-generic.conf
@@ -18,7 +18,7 @@
 # can modify this value, see other parameters).
 # The command can be split into more lines, if necessary, using '\'.
 GenericExecuteSynth \
-"echo \'$DATA\' | espeak -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -q --stdin --pho | mbrola -v $VOLUME -e /usr/share/mbrola/$VOICE/$VOICE - -.au | $PLAY_COMMAND"
+"printf %s \'$DATA\' | espeak -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -q --stdin --pho | mbrola -v $VOLUME -e /usr/share/mbrola/$VOICE/$VOICE - -.au | $PLAY_COMMAND"
 
 GenericCmdDependency "espeak"
 GenericCmdDependency "mbrola"

--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -18,13 +18,13 @@
 # can modify this value, see other parameters).
 # The command can be split into more lines, if necessary, using '\'.
 GenericExecuteSynth \
-"echo \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -q --stdin --pho | mbrola -v $VOLUME -e /usr/share/mbrola/$VOICE/$VOICE - -.au | $PLAY_COMMAND"
+"printf %s \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -q --stdin --pho | mbrola -v $VOLUME -e /usr/share/mbrola/$VOICE/$VOICE - -.au | $PLAY_COMMAND"
 
 # Alternatively you can shorten the command like below, which makes it
 # work directly with any audio playback utility, but then you won't
 # be able to change the volume from the client application:
 # GenericExecuteSynth \
-# "echo \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -stdin"
+# "printf %s \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -stdin"
 
 GenericCmdDependency "espeak-ng"
 GenericCmdDependency "mbrola"

--- a/config/modules/llia_phon-generic.conf
+++ b/config/modules/llia_phon-generic.conf
@@ -18,7 +18,7 @@
 # The command can be split into more lines, if necessary, using '\'.
 
 GenericExecuteSynth \
-"echo \'$DATA\' > $TMPDIR/llia_phon.txt && llia_phon | mbrola --f $PITCH --t $RATE \
+"printf %s \'$DATA\' > $TMPDIR/llia_phon.txt && llia_phon | mbrola --f $PITCH --t $RATE \
 -e -I LIAPHON/data/noarch/initfile.lia (directory with the voice) $VOICE \
 $TMPDIR/llia_phon.txt -.au | $PLAY_COMMAND -t au - >/dev/null"
 

--- a/config/modules/mary-generic-disabled.conf
+++ b/config/modules/mary-generic-disabled.conf
@@ -21,7 +21,7 @@
 # curl if it isn't already installed.
 # The command can be split into more lines, if necessary, using '\'.
 GenericExecuteSynth \
-"curl \"http://localhost:59125/process?INPUT_TEXT=`echo \'$DATA\'| xxd -plain | tr -d '\\n' | sed 's/\\\(..\\\)/%\\\1/g'`&INPUT_TYPE=TEXT&OUTPUT_TYPE=AUDIO&AUDIO=WAVE_FILE&LOCALE=$LANGUAGE&VOICE=$VOICE\" > $TMPDIR/mary-generic.wav && $PLAY_COMMAND $TMPDIR/mary-generic.wav"
+"curl \"http://localhost:59125/process?INPUT_TEXT=`printf %s \'$DATA\'| xxd -plain | tr -d '\\n' | sed 's/\\\(..\\\)/%\\\1/g'`&INPUT_TYPE=TEXT&OUTPUT_TYPE=AUDIO&AUDIO=WAVE_FILE&LOCALE=$LANGUAGE&VOICE=$VOICE\" > $TMPDIR/mary-generic.wav && $PLAY_COMMAND $TMPDIR/mary-generic.wav"
 
 GenericCmdDependency "curl"
 

--- a/config/modules/swift-generic.conf
+++ b/config/modules/swift-generic.conf
@@ -23,7 +23,7 @@
 # can modify this value, see other parameters).
 # The command can be split into more lines, if necessary, using '\'.
 GenericExecuteSynth \
- "echo \'$DATA\' >/tmp/swift-speak.txt && /opt/swift/bin/swift -p speech/rate=$RATE,speech/pitch/shift=$PITCH,tts/content-type=text/plain,tts/text-encoding=utf-8,config/default-voice=$VOICE -f /tmp/swift-speak.txt -o /tmp/swift-speak.wav&& $PLAY_COMMAND /tmp/swift-speak.wav" 
+ "printf %s \'$DATA\' >/tmp/swift-speak.txt && /opt/swift/bin/swift -p speech/rate=$RATE,speech/pitch/shift=$PITCH,tts/content-type=text/plain,tts/text-encoding=utf-8,config/default-voice=$VOICE -f /tmp/swift-speak.txt -o /tmp/swift-speak.wav&& $PLAY_COMMAND /tmp/swift-speak.wav" 
 
 GenericCmdDependency "/opt/swift/bin/swift"
 


### PR DESCRIPTION
printf %s '$DATA' allows to be sure none of $DATA is interpreted. Echo
does not provide this (e.g. DATA=-n).