### PR TITLE
Return "NOT YET IMPLEMENTED" from all history commands.

### DIFF
--- a/src/server/parse.c
+++ b/src/server/parse.c
@@ -273,6 +273,9 @@ enddata:
 char *parse_history(const char *buf, const int bytes, const int fd,
 		    const TSpeechDSock * speechd_socket)
 {
+	return g_strdup(ERR_NOT_IMPLEMENTED);
+
+#if 0
 	char *cmd_main;
 	GET_PARAM_STR(cmd_main, 1, CONV_DOWN);
 
@@ -362,6 +365,7 @@ char *parse_history(const char *buf, const int bytes, const int fd,
 	}
 
 	return g_strdup(ERR_INVALID_COMMAND);
+#endif
 }
 
 #define SSIP_SET_COMMAND(param) \


### PR DESCRIPTION
Most history commands already give not yet implemented response
from what I see in testing locally. however history get client_list
still gives a list of all clients which is not good security wise.
For now always return not yet implemented to all history commands.
At some point we can add some security measures to only give
history for the current client, etc. but just remove all history
until then.