### PR TITLE
pulse: handle _pulse_open() errors in reconnect

### DIFF
--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -257,8 +257,10 @@ static int pulse_play(AudioID * id, AudioTrack track)
 		/* Close old connection if any */
 		pulse_connection_close(pulse_id);
 		/* Open a new connection */
-		_pulse_open(pulse_id, track.sample_rate, track.num_channels,
+		error = _pulse_open(pulse_id, track.sample_rate, track.num_channels,
 			    bytes_per_sample);
+		if (error)
+			return -1;
 		/* Keep track of current connection parameters */
 		pulse_id->pa_current_rate = track.sample_rate;
 		pulse_id->pa_current_bps = track.bits;

--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -259,8 +259,12 @@ static int pulse_play(AudioID * id, AudioTrack track)
 		/* Open a new connection */
 		error = _pulse_open(pulse_id, track.sample_rate, track.num_channels,
 			    bytes_per_sample);
-		if (error)
+		if (error) {
+			pulse_id->pa_current_rate = -1;
+			pulse_id->pa_current_bps = -1;
+			pulse_id->pa_current_channels = -1;
 			return -1;
+		}
 		/* Keep track of current connection parameters */
 		pulse_id->pa_current_rate = track.sample_rate;
 		pulse_id->pa_current_bps = track.bits;


### PR DESCRIPTION
When the sample format changes and we try to reopen our pulseaudio
connection, check for errors or else we end up passing a NULL to
pw_simple_write() and cause an abort.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1770778