### PR TITLE
spd-say: Fix synthesizing percent

### DIFF
--- a/src/clients/say/say.c
+++ b/src/clients/say/say.c
@@ -353,7 +353,7 @@ int main(int argc, char **argv)
 		/* Or do nothing in case of -C or -S with no message. */
 		if (optind < argc) {
 			err =
-			    spd_sayf(conn, spd_priority, (char *)argv[optind]);
+			    spd_sayf(conn, spd_priority, "%s", (char *)argv[optind]);
 			if (err == -1) {
 				fprintf(stderr,
 					"Speech Dispatcher failed to say message");


### PR DESCRIPTION
spd_sayf interprets the string as a printf format, so we need to use %s
instead.