### PR TITLE
doc: Fix synthesizing percent

### DIFF
--- a/doc/speech-dispatcher.html
+++ b/doc/speech-dispatcher.html
@@ -2493,7 +2493,7 @@ main(int argc, char **argv)
    spd_set_notification_on(conn, SPD_CANCEL);
 
    /* Say our message. */
-   spd_sayf(conn, SPD_MESSAGE, (char*) argv[1]);
+   spd_sayf(conn, SPD_MESSAGE, &quot;%s&quot;, argv[1]);
 
    /* Wait for 'end' or 'cancel' of the sent message.
       By SSIP specifications, we are guaranteed to get

--- a/doc/speech-dispatcher.texi
+++ b/doc/speech-dispatcher.texi
@@ -2230,7 +2230,7 @@ main(int argc, char **argv)
    spd_set_notification_on(conn, SPD_CANCEL);
 
    /* Say our message. */
-   spd_sayf(conn, SPD_MESSAGE, (char*) argv[1]);
+   spd_sayf(conn, SPD_MESSAGE, "%s", argv[1]);
 
    /* Wait for 'end' or 'cancel' of the sent message.
       By SSIP specifications, we are guaranteed to get


### PR DESCRIPTION
spd_sayf interprets the string as a printf format, so we need to use %s
instead.