### PR TITLE
ibmtts: harmonize with voxin module source

### DIFF
--- a/src/modules/ibmtts.c
+++ b/src/modules/ibmtts.c
@@ -27,12 +27,12 @@
         A synthesis thread that accepts messages, parses them, and forwards
             them to the IBM TTS via the Eloquence Command Interface (ECI).
             This thread receives audio and index mark callbacks from
-            IBM TTS and queues them into a playback queue. See _ibmtts_synth().
+            IBM TTS and queues them into a playback queue. See _synth().
         A playback thread that acts on entries in the playback queue,
             either sending them to the audio output module (module_tts_output()),
-            or emitting Speech Dispatcher events.  See _ibmtts_play().
+            or emitting Speech Dispatcher events.  See _play().
         A thread which is used to stop or pause the synthesis and
-            playback threads.  See _ibmtts_stop_or_pause().
+            playback threads.  See _stop_or_pause().
 
    Semaphores and mutexes are used to mediate between the 4 threads.
 
@@ -59,12 +59,11 @@
 #include <speechd_types.h>
 #include "module_utils.h"
 
-typedef enum { IBMTTS_FALSE, IBMTTS_TRUE } TIbmttsBool;
 typedef enum {
-	FATAL_ERROR = -1,
-	OK = 0,
-	ERROR = 1
-} TIbmttsSuccess;
+	MODULE_FATAL_ERROR = -1,
+	MODULE_OK = 0,
+	MODULE_ERROR = 1
+} module_status;
 
 /* TODO: These defines are in src/server/index_marking.h, but including that
          file here causes a redefinition error on FATAL macro in speechd.h. */
@@ -78,6 +77,7 @@ typedef enum {
 #define SD_MARK_TAIL_LEN 3
 
 #define MODULE_NAME     "ibmtts"
+#define DBG_MODNAME     "Ibmtts: "
 #define MODULE_VERSION  "0.1"
 
 #define DEBUG_MODULE 1
@@ -154,26 +154,26 @@ DECLARE_DEBUG();
 	}
 
 /* Thread and process control. */
-static pthread_t ibmtts_synth_thread;
-static pthread_t ibmtts_play_thread;
-static pthread_t ibmtts_stop_or_pause_thread;
+static pthread_t synth_thread;
+static pthread_t play_thread;
+static pthread_t stop_or_pause_thread;
 
-static sem_t ibmtts_synth_semaphore;
-static sem_t ibmtts_play_semaphore;
-static sem_t ibmtts_stop_or_pause_semaphore;
+static sem_t synth_semaphore;
+static sem_t play_semaphore;
+static sem_t stop_or_pause_semaphore;
 
-static pthread_mutex_t ibmtts_synth_suspended_mutex;
-static pthread_mutex_t ibmtts_play_suspended_mutex;
-static pthread_mutex_t ibmtts_stop_or_pause_suspended_mutex;
+static pthread_mutex_t synth_suspended_mutex;
+static pthread_mutex_t play_suspended_mutex;
+static pthread_mutex_t stop_or_pause_suspended_mutex;
 
-static TIbmttsBool ibmtts_thread_exit_requested = IBMTTS_FALSE;
-static TIbmttsBool ibmtts_stop_synth_requested = IBMTTS_FALSE;
-static TIbmttsBool ibmtts_stop_play_requested = IBMTTS_FALSE;
-static TIbmttsBool ibmtts_pause_requested = IBMTTS_FALSE;
+static gboolean thread_exit_requested = FALSE;
+static gboolean stop_synth_requested = FALSE;
+static gboolean stop_play_requested = FALSE;
+static gboolean pause_requested = FALSE;
 
 /* Current message from Speech Dispatcher. */
-static char **ibmtts_message;
-static SPDMessageType ibmtts_message_type;
+static char **message;
+static SPDMessageType message_type;
 
 /* ECI */
 static ECIHand eciHandle = NULL_ECI_HAND;
@@ -195,11 +195,11 @@ typedef enum {
 
 /* The playback queue. */
 typedef enum {
-	IBMTTS_QET_AUDIO,	/* Chunk of audio. */
-	IBMTTS_QET_INDEX_MARK,	/* Index mark event. */
-	IBMTTS_QET_SOUND_ICON,	/* A Sound Icon */
-	IBMTTS_QET_BEGIN,	/* Beginning of speech. */
-	IBMTTS_QET_END		/* Speech completed. */
+	QET_AUDIO,	/* Chunk of audio. */
+	QET_INDEX_MARK,	/* Index mark event. */
+	QET_SOUND_ICON,	/* A Sound Icon */
+	QET_BEGIN,	/* Beginning of speech. */
+	QET_END		/* Speech completed. */
 } EPlaybackQueueEntryType;
 
 typedef struct {
@@ -220,81 +220,81 @@ static GSList *playback_queue = NULL;
 static pthread_mutex_t playback_queue_mutex;
 
 /* A lookup table for index mark name given integer id. */
-GHashTable *ibmtts_index_mark_ht = NULL;
-#define IBMTTS_MSG_END_MARK 0
+static GHashTable *index_mark_ht = NULL;
+#define MSG_END_MARK 0
 
-pthread_mutex_t sound_stop_mutex;
+static pthread_mutex_t sound_stop_mutex;
 
 /* When a voice is set, this is the baseline pitch of the voice.
    SSIP PITCH commands then adjust relative to this. */
-int ibmtts_voice_pitch_baseline;
+static int voice_pitch_baseline;
 /* When a voice is set, this the default speed of the voice.
    SSIP RATE commands then adjust relative to this. */
-int ibmtts_voice_speed;
+static int voice_speed;
 
 /* Expected input encoding for current language dialect. */
-static char *ibmtts_input_encoding = "cp1252";
+static char *input_encoding = "cp1252";
 
-/* list of voices */
-static SPDVoice **ibmtts_voice_list = NULL;
-static int *ibmtts_voice_index = NULL;
+/* list of speechd voices */
+static SPDVoice **speechd_voice = NULL;
+static int *speechd_voice_index = NULL;
 
 /* Internal function prototypes for main thread. */
-static void ibmtts_set_language(char *lang);
-static void ibmtts_set_voice(SPDVoiceType voice);
-static char *ibmtts_voice_enum_to_str(SPDVoiceType voice);
-static void ibmtts_set_language_and_voice(char *lang, SPDVoiceType voice,
-					  char *dialect);
-static void ibmtts_set_synthesis_voice(char *);
-static void ibmtts_set_rate(signed int rate);
-static void ibmtts_set_pitch(signed int pitch);
-static void ibmtts_set_punctuation_mode(SPDPunctuation punct_mode);
-static void ibmtts_set_volume(signed int pitch);
+static void update_sample_rate();
+static void set_language(char *lang);
+static void set_voice_type(SPDVoiceType voice_type);
+static char *voice_enum_to_str(SPDVoiceType voice);
+static void set_language_and_voice(char *lang, SPDVoiceType voice_type, char *dialect);
+static void set_synthesis_voice(char *);
+static void set_rate(signed int rate);
+static void set_pitch(signed int pitch);
+static void set_punctuation_mode(SPDPunctuation punct_mode);
+static void set_volume(signed int pitch);
 
 /* locale_index_atomic stores the current index of the eciLocales array.
-The main thread writes this information, the synthesis thread reads it.
+   The main thread writes this information, the synthesis thread reads it.
 */
 static gint locale_index_atomic;
 
 /* Internal function prototypes for synthesis thread. */
-static char *ibmtts_extract_mark_name(char *mark);
-static char *ibmtts_next_part(char *msg, char **mark_name);
-static int ibmtts_replace(char *from, char *to, GString * msg);
-static void ibmtts_subst_keys_cb(gpointer data, gpointer user_data);
-static char *ibmtts_subst_keys(char *key);
-static char *ibmtts_search_for_sound_icon(const char *icon_name);
-static TIbmttsBool ibmtts_add_sound_icon_to_playback_queue(char *filename);
-static void ibmtts_load_user_dictionary();
+static char *extract_mark_name(char *mark);
+static char *next_part(char *msg, char **mark_name);
+static int replace(char *from, char *to, GString * msg);
+static void subst_keys_cb(gpointer data, gpointer user_data);
+static char *subst_keys(char *key);
+static char *search_for_sound_icon(const char *icon_name);
+static gboolean add_sound_icon_to_playback_queue(char *filename);
+static void load_user_dictionary();
 
 static enum ECICallbackReturn eciCallback(ECIHand hEngine,
 					  enum ECIMessage msg,
 					  long lparam, void *data);
 
 /* Internal function prototypes for playback thread. */
-static TIbmttsBool ibmtts_add_audio_to_playback_queue(TEciAudioSamples *
+static gboolean add_audio_to_playback_queue(TEciAudioSamples *
 						      audio_chunk,
 						      long num_samples);
-static TIbmttsBool ibmtts_add_mark_to_playback_queue(long markId);
-static TIbmttsBool ibmtts_add_flag_to_playback_queue(EPlaybackQueueEntryType
+static gboolean add_mark_to_playback_queue(long markId);
+static gboolean add_flag_to_playback_queue(EPlaybackQueueEntryType
 						     type);
-static void ibmtts_delete_playback_queue_entry(TPlaybackQueueEntry *
+static void delete_playback_queue_entry(TPlaybackQueueEntry *
 					       playback_queue_entry);
-static TIbmttsBool ibmtts_send_to_audio(TPlaybackQueueEntry *
+static gboolean send_to_audio(TPlaybackQueueEntry *
 					playback_queue_entry);
 
 /* Miscellaneous internal function prototypes. */
-static TIbmttsBool is_thread_busy(pthread_mutex_t * suspended_mutex);
-static void ibmtts_log_eci_error();
-static void ibmtts_clear_playback_queue();
+static gboolean is_thread_busy(pthread_mutex_t * suspended_mutex);
+static void log_eci_error();
+static void clear_playback_queue();
 static void alloc_voice_list();
 static void free_voice_list();
 
 /* The synthesis thread start routine. */
-static void *_ibmtts_synth(void *);
+static void *_synth(void *);
 /* The playback thread start routine. */
-static void *_ibmtts_play(void *);
+static void *_play(void *);
 /* The stop_or_pause start routine. */
-static void *_ibmtts_stop_or_pause(void *);
+static void *_stop_or_pause(void *);
 
 /* Module configuration options. */
 MOD_OPTION_1_INT(IbmttsUseSSML);
@@ -397,67 +397,51 @@ int module_load(void)
 	/* Register key substitutions. */
 	MOD_OPTION_HT_DLL_REG(IbmttsKeySubstitution);
 
-	return OK;
+	return MODULE_OK;
 }
 
 int module_init(char **status_info)
 {
 	int ret;
-	char ibmVersion[20];
-	int ibm_sample_rate;
+	char version[20];
 
-	DBG("Ibmtts: Module init().");
+	DBG(DBG_MODNAME "Module init().");
 	INIT_INDEX_MARKING();
 
 	*status_info = NULL;
-	ibmtts_thread_exit_requested = IBMTTS_FALSE;
+	thread_exit_requested = FALSE;
 
 	/* Report versions. */
-	eciVersion(ibmVersion);
-	DBG("Ibmtts: IBM TTS Output Module version %s, IBM TTS Engine version %s", MODULE_VERSION, ibmVersion);
+	eciVersion(version);
+	DBG(DBG_MODNAME "IBM TTS Output Module version %s, IBM TTS Engine version %s", MODULE_VERSION, version);
 
 	/* TODO: according to version, enable SSML and punct by default or not
 	 */
 
 	/* Setup IBM TTS engine. */
-	DBG("Ibmtts: Creating ECI instance.");
+	DBG(DBG_MODNAME "Creating ECI instance.");
 	eciHandle = eciNew();
 	if (NULL_ECI_HAND == eciHandle) {
-		DBG("Ibmtts: Could not create ECI instance.\n");
+		DBG(DBG_MODNAME "Could not create ECI instance.\n");
 		*status_info = g_strdup("Could not create ECI instance. "
 					"Is the IBM TTS engine installed?");
-		return FATAL_ERROR;
+		return MODULE_FATAL_ERROR;
 	}
 
-	/* Get ECI audio sample rate. */
-	ibm_sample_rate = eciGetParam(eciHandle, eciSampleRate);
-	switch (ibm_sample_rate) {
-	case 0:
-		eci_sample_rate = 8000;
-		break;
-	case 1:
-		eci_sample_rate = 11025;
-		break;
-	case 2:
-		eci_sample_rate = 22050;
-		break;
-	default:
-		DBG("Ibmtts: Invalid audio sample rate returned by ECI = %i",
-		    ibm_sample_rate);
-	}
+	update_sample_rate();
 
 	/* Allocate a chunk for ECI to return audio. */
 	audio_chunk =
 	    (TEciAudioSamples *) g_malloc((IbmttsAudioChunkSize) *
 					  sizeof(TEciAudioSamples));
 
-	DBG("Ibmtts: Registering ECI callback.");
+	DBG(DBG_MODNAME "Registering ECI callback.");
 	eciRegisterCallback(eciHandle, eciCallback, NULL);
 
-	DBG("Ibmtts: Registering an ECI audio buffer.");
+	DBG(DBG_MODNAME "Registering an ECI audio buffer.");
 	if (!eciSetOutputBuffer(eciHandle, IbmttsAudioChunkSize, audio_chunk)) {
-		DBG("Ibmtts: Error registering ECI audio buffer.");
-		ibmtts_log_eci_error();
+		DBG(DBG_MODNAME "Error registering ECI audio buffer.");
+		log_eci_error();
 	}
 
 	eciSetParam(eciHandle, eciDictionary, !IbmttsUseAbbreviation);
@@ -472,13 +456,13 @@ int module_init(char **status_info)
 	/* load possibly the punctuation filter */
 	eciAddText(eciHandle, " `gfa2 ");
 
-	ibmtts_set_punctuation_mode(msg_settings.punctuation_mode);
+	set_punctuation_mode(msg_settings.punctuation_mode);
 
 	alloc_voice_list();
 
 	/* These mutexes are locked when the corresponding threads are suspended. */
-	pthread_mutex_init(&ibmtts_synth_suspended_mutex, NULL);
-	pthread_mutex_init(&ibmtts_play_suspended_mutex, NULL);
+	pthread_mutex_init(&synth_suspended_mutex, NULL);
+	pthread_mutex_init(&play_suspended_mutex, NULL);
 
 	/* This mutex is used to hold a stop request until audio actually stops. */
 	pthread_mutex_init(&sound_stop_mutex, NULL);
@@ -487,157 +471,156 @@ int module_init(char **status_info)
 	   playback threads. */
 	pthread_mutex_init(&playback_queue_mutex, NULL);
 
-	DBG("Ibmtts: ImbttsAudioChunkSize = %d", IbmttsAudioChunkSize);
+	DBG(DBG_MODNAME "IbmttsAudioChunkSize = %d", IbmttsAudioChunkSize);
 
-	ibmtts_message = g_malloc(sizeof(char *));
-	*ibmtts_message = NULL;
+	message = g_malloc(sizeof(char *));
+	*message = NULL;
 
-	DBG("Ibmtts: Creating new thread for stop or pause.");
-	sem_init(&ibmtts_stop_or_pause_semaphore, 0, 0);
+	DBG(DBG_MODNAME "Creating new thread for stop or pause.");
+	sem_init(&stop_or_pause_semaphore, 0, 0);
 
-	ret =
-	    pthread_create(&ibmtts_stop_or_pause_thread, NULL,
-			   _ibmtts_stop_or_pause, NULL);
+	ret = pthread_create(&stop_or_pause_thread, NULL,
+			   _stop_or_pause, NULL);
 	if (0 != ret) {
-		DBG("Ibmtts: stop or pause thread creation failed.");
+		DBG(DBG_MODNAME "stop or pause thread creation failed.");
 		*status_info =
 		    g_strdup
 		    ("The module couldn't initialize stop or pause thread. "
 		     "This could be either an internal problem or an "
 		     "architecture problem. If you are sure your architecture "
 		     "supports threads, please report a bug.");
-		return FATAL_ERROR;
+		return MODULE_FATAL_ERROR;
 	}
 
-	DBG("Ibmtts: Creating new thread for playback.");
-	sem_init(&ibmtts_play_semaphore, 0, 0);
+	DBG(DBG_MODNAME "Creating new thread for playback.");
+	sem_init(&play_semaphore, 0, 0);
 
-	ret = pthread_create(&ibmtts_play_thread, NULL, _ibmtts_play, NULL);
+	ret = pthread_create(&play_thread, NULL, _play, NULL);
 	if (0 != ret) {
-		DBG("Ibmtts: play thread creation failed.");
+		DBG(DBG_MODNAME "play thread creation failed.");
 		*status_info =
 		    g_strdup("The module couldn't initialize play thread. "
 			     "This could be either an internal problem or an "
 			     "architecture problem. If you are sure your architecture "
 			     "supports threads, please report a bug.");
-		return FATAL_ERROR;
+		return MODULE_FATAL_ERROR;
 	}
 
-	DBG("Ibmtts: Creating new thread for IBM TTS synthesis.");
-	sem_init(&ibmtts_synth_semaphore, 0, 0);
+	DBG(DBG_MODNAME "Creating new thread for TTS synthesis.");
+	sem_init(&synth_semaphore, 0, 0);
 
-	ret = pthread_create(&ibmtts_synth_thread, NULL, _ibmtts_synth, NULL);
+	ret = pthread_create(&synth_thread, NULL, _synth, NULL);
 	if (0 != ret) {
-		DBG("Ibmtts: synthesis thread creation failed.");
+		DBG(DBG_MODNAME "synthesis thread creation failed.");
 		*status_info =
 		    g_strdup("The module couldn't initialize synthesis thread. "
 			     "This could be either an internal problem or an "
 			     "architecture problem. If you are sure your architecture "
 			     "supports threads, please report a bug.");
-		return FATAL_ERROR;
+		return MODULE_FATAL_ERROR;
 	}
 
-	*status_info = g_strdup("Ibmtts: Initialized successfully.");
+	*status_info = g_strdup(DBG_MODNAME "Initialized successfully.");
 
-	return OK;
+	return MODULE_OK;
 }
 
 SPDVoice **module_list_voices(void)
 {
-	DBG("Ibmtts: %s", __FUNCTION__);
-	return ibmtts_voice_list;
+	DBG(DBG_MODNAME "ENTER %s", __func__);
+	return speechd_voice;
 }
 
 int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 {
-	DBG("Ibmtts: module_speak().");
+	DBG(DBG_MODNAME "module_speak().");
 
-	if (is_thread_busy(&ibmtts_synth_suspended_mutex) ||
-	    is_thread_busy(&ibmtts_play_suspended_mutex) ||
-	    is_thread_busy(&ibmtts_stop_or_pause_suspended_mutex)) {
-		DBG("Ibmtts: Already synthesizing when requested to synthesize (module_speak).");
-		return IBMTTS_FALSE;
+	if (is_thread_busy(&synth_suspended_mutex) ||
+	    is_thread_busy(&play_suspended_mutex) ||
+	    is_thread_busy(&stop_or_pause_suspended_mutex)) {
+		DBG(DBG_MODNAME "Already synthesizing when requested to synthesize (module_speak).");
+		return FALSE;
 	}
 
-	DBG("Ibmtts: Type: %d, bytes: %lu, requested data: |%s|\n", msgtype,
+	DBG(DBG_MODNAME "Type: %d, bytes: %lu, requested data: |%s|\n", msgtype,
 	    (unsigned long)bytes, data);
 
-	g_free(*ibmtts_message);
-	*ibmtts_message = NULL;
+	g_free(*message);
+	*message = NULL;
 
 	if (!g_utf8_validate(data, bytes, NULL)) {
-		DBG("Ibmtts: Input is not valid utf-8.");
+		DBG(DBG_MODNAME "Input is not valid utf-8.");
 		/* Actually, we should just fail here, but let's assume input is latin-1 */
-		*ibmtts_message =
+		*message =
 		    g_convert(data, bytes, "utf-8", "iso-8859-1", NULL, NULL,
 			      NULL);
-		if (*ibmtts_message == NULL) {
-			DBG("Ibmtts: Fallback conversion to utf-8 failed.");
+		if (*message == NULL) {
+			DBG(DBG_MODNAME "Fallback conversion to utf-8 failed.");
 			return FALSE;
 		}
 	} else {
-		*ibmtts_message = g_strndup(data, bytes);
+		*message = g_strndup(data, bytes);
 	}
 
-	ibmtts_message_type = msgtype;
+	message_type = msgtype;
 	if ((msgtype == SPD_MSGTYPE_TEXT)
 	    && (msg_settings.spelling_mode == SPD_SPELL_ON))
-		ibmtts_message_type = SPD_MSGTYPE_SPELL;
+		message_type = SPD_MSGTYPE_SPELL;
 
 	/* Setting speech parameters. */
-	UPDATE_STRING_PARAMETER(voice.language, ibmtts_set_language);
-	UPDATE_PARAMETER(voice_type, ibmtts_set_voice);
-	UPDATE_STRING_PARAMETER(voice.name, ibmtts_set_synthesis_voice);
-	UPDATE_PARAMETER(rate, ibmtts_set_rate);
-	UPDATE_PARAMETER(volume, ibmtts_set_volume);
-	UPDATE_PARAMETER(pitch, ibmtts_set_pitch);
-	UPDATE_PARAMETER(punctuation_mode, ibmtts_set_punctuation_mode);
+	UPDATE_STRING_PARAMETER(voice.language, set_language);
+	UPDATE_PARAMETER(voice_type, set_voice_type);
+	UPDATE_STRING_PARAMETER(voice.name, set_synthesis_voice);
+	UPDATE_PARAMETER(rate, set_rate);
+	UPDATE_PARAMETER(volume, set_volume);
+	UPDATE_PARAMETER(pitch, set_pitch);
+	UPDATE_PARAMETER(punctuation_mode, set_punctuation_mode);
 
-	/* TODO: Handle these in _ibmtts_synth() ?
+	/* TODO: Handle these in _synth() ?
 	   UPDATE_PARAMETER(cap_let_recogn, festival_set_cap_let_recogn);
 	 */
 
 	if (!IbmttsUseSSML) {
 		/* Strip all SSML */
-		char *tmp = *ibmtts_message;
-		*ibmtts_message = module_strip_ssml(*ibmtts_message);
+		char *tmp = *message;
+		*message = module_strip_ssml(*message);
 		g_free(tmp);
 		/* Convert input to suitable encoding for current language dialect */
 		tmp =
-		    g_convert_with_fallback(*ibmtts_message, -1,
-					    ibmtts_input_encoding, "utf-8", "?",
+		    g_convert_with_fallback(*message, -1,
+					    input_encoding, "utf-8", "?",
 					    NULL, &bytes, NULL);
 		if (tmp != NULL) {
-			g_free(*ibmtts_message);
-			*ibmtts_message = tmp;
+			g_free(*message);
+			*message = tmp;
 		}
 	}
 
 	/* Send semaphore signal to the synthesis thread */
-	sem_post(&ibmtts_synth_semaphore);
+	sem_post(&synth_semaphore);
 
-	DBG("Ibmtts: Leaving module_speak() normally.");
+	DBG(DBG_MODNAME "Leaving module_speak() normally.");
 	return TRUE;
 }
 
 int module_stop(void)
 {
-	DBG("Ibmtts: module_stop().");
+	DBG(DBG_MODNAME "module_stop().");
 
-	if ((is_thread_busy(&ibmtts_synth_suspended_mutex) ||
-	     is_thread_busy(&ibmtts_play_suspended_mutex)) &&
-	    !is_thread_busy(&ibmtts_stop_or_pause_suspended_mutex)) {
+	if ((is_thread_busy(&synth_suspended_mutex) ||
+	     is_thread_busy(&play_suspended_mutex)) &&
+	    !is_thread_busy(&stop_or_pause_suspended_mutex)) {
 
 		/* Request both synth and playback threads to stop what they are doing
 		   (if anything). */
-		ibmtts_stop_synth_requested = IBMTTS_TRUE;
-		ibmtts_stop_play_requested = IBMTTS_TRUE;
+		stop_synth_requested = TRUE;
+		stop_play_requested = TRUE;
 
 		/* Wake the stop_or_pause thread. */
-		sem_post(&ibmtts_stop_or_pause_semaphore);
+		sem_post(&stop_or_pause_semaphore);
 	}
 
-	return OK;
+	return MODULE_OK;
 }
 
 size_t module_pause(void)
@@ -649,33 +632,33 @@ size_t module_pause(void)
 	   make use of it because Speech Dispatcher doesn't have a module_resume
 	   function. Instead, Speech Dispatcher resumes by calling module_speak
 	   from the last index mark reported in the text. */
-	DBG("Ibmtts: module_pause().");
+	DBG(DBG_MODNAME "module_pause().");
 
 	/* Request playback thread to pause.  Note we cannot stop synthesis or
 	   playback until end of sentence or end of message is played. */
-	ibmtts_pause_requested = IBMTTS_TRUE;
+	pause_requested = TRUE;
 
 	/* Wake the stop_or_pause thread. */
-	sem_post(&ibmtts_stop_or_pause_semaphore);
+	sem_post(&stop_or_pause_semaphore);
 
-	return OK;
+	return MODULE_OK;
 }
 
 int module_close(void)
 {
 
-	DBG("Ibmtts: close().");
+	DBG(DBG_MODNAME "close().");
 
-	if (is_thread_busy(&ibmtts_synth_suspended_mutex) ||
-	    is_thread_busy(&ibmtts_play_suspended_mutex)) {
-		DBG("Ibmtts: Stopping speech");
+	if (is_thread_busy(&synth_suspended_mutex) ||
+	    is_thread_busy(&play_suspended_mutex)) {
+		DBG(DBG_MODNAME "Stopping speech");
 		module_stop();
 	}
 
-	DBG("Ibmtts: De-registering ECI callback.");
+	DBG(DBG_MODNAME "De-registering ECI callback.");
 	eciRegisterCallback(eciHandle, NULL, NULL);
 
-	DBG("Ibmtts: Destroying ECI instance.");
+	DBG(DBG_MODNAME "Destroying ECI instance.");
 	eciDelete(eciHandle);
 	eciHandle = NULL_ECI_HAND;
 
@@ -683,44 +666,67 @@ int module_close(void)
 	g_free(audio_chunk);
 
 	/* Request each thread exit and wait until it exits. */
-	DBG("Ibmtts: Terminating threads");
-	ibmtts_thread_exit_requested = IBMTTS_TRUE;
-	sem_post(&ibmtts_synth_semaphore);
-	sem_post(&ibmtts_play_semaphore);
-	sem_post(&ibmtts_stop_or_pause_semaphore);
-	if (0 != pthread_join(ibmtts_synth_thread, NULL))
+	DBG(DBG_MODNAME "Terminating threads");
+	thread_exit_requested = TRUE;
+	sem_post(&synth_semaphore);
+	sem_post(&play_semaphore);
+	sem_post(&stop_or_pause_semaphore);
+	if (0 != pthread_join(synth_thread, NULL))
 		return -1;
-	if (0 != pthread_join(ibmtts_play_thread, NULL))
+	if (0 != pthread_join(play_thread, NULL))
 		return -1;
-	if (0 != pthread_join(ibmtts_stop_or_pause_thread, NULL))
+	if (0 != pthread_join(stop_or_pause_thread, NULL))
 		return -1;
 
-	ibmtts_clear_playback_queue();
+	clear_playback_queue();
 
 	/* Free index mark lookup table. */
-	if (ibmtts_index_mark_ht) {
-		g_hash_table_destroy(ibmtts_index_mark_ht);
-		ibmtts_index_mark_ht = NULL;
+	if (index_mark_ht) {
+		g_hash_table_destroy(index_mark_ht);
+		index_mark_ht = NULL;
 	}
 
 	free_voice_list();
-	sem_destroy(&ibmtts_synth_semaphore);
-	sem_destroy(&ibmtts_play_semaphore);
-	sem_destroy(&ibmtts_stop_or_pause_semaphore);
+	sem_destroy(&synth_semaphore);
+	sem_destroy(&play_semaphore);
+	sem_destroy(&stop_or_pause_semaphore);
 
 	return 0;
 }
 
 /* Internal functions */
 
-/* Return true if the thread is busy, i.e., suspended mutex is not locked. */
-static TIbmttsBool is_thread_busy(pthread_mutex_t * suspended_mutex)
+static void update_sample_rate()
+{
+	//	DBG(DBG_MODNAME "ENTER %s", __func__);
+	int sample_rate;
+	/* Get ECI audio sample rate. */
+	sample_rate = eciGetParam(eciHandle, eciSampleRate);
+	switch (sample_rate) {
+	case 0:
+		eci_sample_rate = 8000;
+		break;
+	case 1:
+		eci_sample_rate = 11025;
+		break;
+	case 2:
+		eci_sample_rate = 22050;
+		break;
+	default:
+		DBG(DBG_MODNAME "Invalid audio sample rate returned by ECI = %i",
+		    sample_rate);
+	}
+	DBG(DBG_MODNAME "LEAVE %s, eci_sample_rate=%d",  __FUNCTION__, eci_sample_rate);  
+}
+
+/* Return TRUE if the thread is busy, i.e., suspended mutex is not locked. */
+static gboolean is_thread_busy(pthread_mutex_t * suspended_mutex)
 {
 	if (EBUSY == pthread_mutex_trylock(suspended_mutex))
-		return IBMTTS_FALSE;
+		return FALSE;
 	else {
 		pthread_mutex_unlock(suspended_mutex);
-		return IBMTTS_TRUE;
+		return TRUE;
 	}
 }
 
@@ -728,7 +734,7 @@ static TIbmttsBool is_thread_busy(pthread_mutex_t * suspended_mutex)
    <mark name="some_name"/>, returns some_name.  Calling routine is
    responsible for freeing returned string. If an error occurs,
    returns NULL. */
-static char *ibmtts_extract_mark_name(char *mark)
+static char *extract_mark_name(char *mark)
 {
 	if ((SD_MARK_HEAD_ONLY_LEN + SD_MARK_TAIL_LEN + 1) > strlen(mark))
 		return NULL;
@@ -747,17 +753,17 @@ static char *ibmtts_extract_mark_name(char *mark)
    Caller is responsible for freeing both returned string and mark_name (if not NULL). */
 /* TODO: This routine needs to be more tolerant of custom index marks with spaces. */
 /* TODO: Should there be a MaxChunkLength? Delimiters? */
-static char *ibmtts_next_part(char *msg, char **mark_name)
+static char *next_part(char *msg, char **mark_name)
 {
 	char *mark_head = strstr(msg, SD_MARK_HEAD_ONLY);
 	if (NULL == mark_head)
 		return (char *)g_strndup(msg, strlen(msg));
 	else if (mark_head == msg) {
-		*mark_name = ibmtts_extract_mark_name(mark_head);
+		*mark_name = extract_mark_name(mark_head);
 		if (NULL == *mark_name)
 			return strcat((char *)
 				      g_strndup(msg, SD_MARK_HEAD_ONLY_LEN),
-				      ibmtts_next_part(msg +
+				      next_part(msg +
 						       SD_MARK_HEAD_ONLY_LEN,
 						       mark_name));
 		else
@@ -770,76 +776,76 @@ static char *ibmtts_next_part(char *msg, char **mark_name)
 }
 
 /* Stop or Pause thread. */
-static void *_ibmtts_stop_or_pause(void *nothing)
+static void *_stop_or_pause(void *nothing)
 {
-	DBG("Ibmtts: Stop or pause thread starting.......\n");
+	DBG(DBG_MODNAME "Stop or pause thread starting.......\n");
 
 	/* Block all signals to this thread. */
 	set_speaking_thread_parameters();
 
-	while (!ibmtts_thread_exit_requested) {
+	while (!thread_exit_requested) {
 		/* If semaphore not set, set suspended lock and suspend until it is signaled. */
-		if (0 != sem_trywait(&ibmtts_stop_or_pause_semaphore)) {
+		if (0 != sem_trywait(&stop_or_pause_semaphore)) {
 			pthread_mutex_lock
-			    (&ibmtts_stop_or_pause_suspended_mutex);
-			sem_wait(&ibmtts_stop_or_pause_semaphore);
+			    (&stop_or_pause_suspended_mutex);
+			sem_wait(&stop_or_pause_semaphore);
 			pthread_mutex_unlock
-			    (&ibmtts_stop_or_pause_suspended_mutex);
-			if (ibmtts_thread_exit_requested)
+			    (&stop_or_pause_suspended_mutex);
+			if (thread_exit_requested)
 				break;
 		}
-		DBG("Ibmtts: Stop or pause semaphore on.");
+		DBG(DBG_MODNAME "Stop or pause semaphore on.");
 		/* The following is a hack. The condition should never
 		   be true, but sometimes it is true for unclear reasons. */
-		if (!(ibmtts_stop_synth_requested || ibmtts_pause_requested))
+		if (!(stop_synth_requested || pause_requested))
 			continue;
 
-		if (ibmtts_stop_synth_requested) {
+		if (stop_synth_requested) {
 			/* Stop synthesis (if in progress). */
 			if (eciHandle) {
-				DBG("Ibmtts: Stopping synthesis.");
+				DBG(DBG_MODNAME "Stopping synthesis.");
 				eciStop(eciHandle);
 			}
 
 			/* Stop any audio playback (if in progress). */
 			if (module_audio_id) {
 				pthread_mutex_lock(&sound_stop_mutex);
-				DBG("Ibmtts: Stopping audio.");
+				DBG(DBG_MODNAME "Stopping audio.");
 				int ret = spd_audio_stop(module_audio_id);
 				if (0 != ret)
-					DBG("Ibmtts: WARNING: Non 0 value from spd_audio_stop: %d", ret);
+					DBG(DBG_MODNAME "WARNING: Non 0 value from spd_audio_stop: %d", ret);
 				pthread_mutex_unlock(&sound_stop_mutex);
 			}
 		}
 
-		DBG("Ibmtts: Waiting for synthesis thread to suspend.");
-		while (is_thread_busy(&ibmtts_synth_suspended_mutex))
+		DBG(DBG_MODNAME "Waiting for synthesis thread to suspend.");
+		while (is_thread_busy(&synth_suspended_mutex))
 			g_usleep(100);
-		DBG("Ibmtts: Waiting for playback thread to suspend.");
-		while (is_thread_busy(&ibmtts_play_suspended_mutex))
+		DBG(DBG_MODNAME "Waiting for playback thread to suspend.");
+		while (is_thread_busy(&play_suspended_mutex))
 			g_usleep(100);
 
-		DBG("Ibmtts: Clearing playback queue.");
-		ibmtts_clear_playback_queue();
+		DBG(DBG_MODNAME "Clearing playback queue.");
+		clear_playback_queue();
 
-		DBG("Ibmtts: Clearing index mark lookup table.");
-		if (ibmtts_index_mark_ht) {
-			g_hash_table_destroy(ibmtts_index_mark_ht);
-			ibmtts_index_mark_ht = NULL;
+		DBG(DBG_MODNAME "Clearing index mark lookup table.");
+		if (index_mark_ht) {
+			g_hash_table_destroy(index_mark_ht);
+			index_mark_ht = NULL;
 		}
 
-		if (ibmtts_stop_synth_requested)
+		if (stop_synth_requested)
 			module_report_event_stop();
 		else
 			module_report_event_pause();
 
-		ibmtts_stop_synth_requested = IBMTTS_FALSE;
-		ibmtts_stop_play_requested = IBMTTS_FALSE;
-		ibmtts_pause_requested = IBMTTS_FALSE;
+		stop_synth_requested = FALSE;
+		stop_play_requested = FALSE;
+		pause_requested = FALSE;
 
-		DBG("Ibmtts: Stop or pause completed.");
+		DBG(DBG_MODNAME "Stop or pause completed.");
 	}
-	DBG("Ibmtts: Stop or pause thread ended.......\n");
+	DBG(DBG_MODNAME "Stop or pause thread ended.......\n");
 
 	pthread_exit(NULL);
 }
@@ -850,18 +856,18 @@ static int process_text_mark(char *part, int part_len, char *mark_name)
 	if (NULL != mark_name) {
 		/* Assign the mark name an integer number and store in lookup table. */
 		int *markId = (int *)g_malloc(sizeof(int));
-		*markId = 1 + g_hash_table_size(ibmtts_index_mark_ht);
-		g_hash_table_insert(ibmtts_index_mark_ht, markId, mark_name);
+		*markId = 1 + g_hash_table_size(index_mark_ht);
+		g_hash_table_insert(index_mark_ht, markId, mark_name);
 		if (!eciInsertIndex(eciHandle, *markId)) {
-			DBG("Ibmtts: Error sending index mark to synthesizer.");
-			ibmtts_log_eci_error();
+			DBG(DBG_MODNAME "Error sending index mark to synthesizer.");
+			log_eci_error();
 			/* Try to keep going. */
 		} else
-			DBG("Ibmtts: Index mark |%s| (id %i) sent to synthesizer.", mark_name, *markId);
+			DBG(DBG_MODNAME "Index mark |%s| (id %i) sent to synthesizer.", mark_name, *markId);
 		/* If pause is requested, skip over rest of message,
 		   but synthesize what we have so far. */
-		if (ibmtts_pause_requested) {
-			DBG("Ibmtts: Pause requested in synthesis thread.");
+		if (pause_requested) {
+			DBG(DBG_MODNAME "Pause requested in synthesis thread.");
 			return 1;
 		}
 		return 0;
@@ -869,51 +875,51 @@ static int process_text_mark(char *part, int part_len, char *mark_name)
 
 	/* Handle normal text. */
 	if (part_len > 0) {
-		DBG("Ibmtts: Returned %d bytes from get_part.", part_len);
-		DBG("Ibmtts: Text to synthesize is |%s|\n", part);
-		DBG("Ibmtts: Sending text to synthesizer.");
+		DBG(DBG_MODNAME "Returned %d bytes from get_part.", part_len);
+		DBG(DBG_MODNAME "Text to synthesize is |%s|\n", part);
+		DBG(DBG_MODNAME "Sending text to synthesizer.");
 		if (!eciAddText(eciHandle, part)) {
-			DBG("Ibmtts: Error sending text.");
-			ibmtts_log_eci_error();
+			DBG(DBG_MODNAME "Error sending text.");
+			log_eci_error();
 			return 2;
 		}
 		return 0;
 	}
 
 	/* Handle end of text. */
-	DBG("Ibmtts: End of data in synthesis thread.");
+	DBG(DBG_MODNAME "End of data in synthesis thread.");
 	/*
 	   Add index mark for end of message.
 	   This also makes sure the callback gets called at least once
 	 */
-	eciInsertIndex(eciHandle, IBMTTS_MSG_END_MARK);
-	DBG("Ibmtts: Trying to synthesize text.");
+	eciInsertIndex(eciHandle, MSG_END_MARK);
+	DBG(DBG_MODNAME "Trying to synthesize text.");
 	if (!eciSynthesize(eciHandle)) {
-		DBG("Ibmtts: Error synthesizing.");
-		ibmtts_log_eci_error();
+		DBG(DBG_MODNAME "Error synthesizing.");
+		log_eci_error();
 		return 2;;
 	}
 
 	/* Audio and index marks are returned in eciCallback(). */
-	DBG("Ibmtts: Waiting for synthesis to complete.");
+	DBG(DBG_MODNAME "Waiting for synthesis to complete.");
 	if (!eciSynchronize(eciHandle)) {
-		DBG("Ibmtts: Error waiting for synthesis to complete.");
-		ibmtts_log_eci_error();
+		DBG(DBG_MODNAME "Error waiting for synthesis to complete.");
+		log_eci_error();
 		return 2;
 	}
-	DBG("Ibmtts: Synthesis complete.");
+	DBG(DBG_MODNAME "Synthesis complete.");
 	return 3;
 }
 
 /* Synthesis thread. */
-static void *_ibmtts_synth(void *nothing)
+static void *_synth(void *nothing)
 {
 	char *pos = NULL;
 	char *part = NULL;
 	int part_len = 0;
 	int ret;
 
-	DBG("Ibmtts: Synthesis thread starting.......\n");
+	DBG(DBG_MODNAME "Synthesis thread starting.......\n");
 
 	/* Block all signals to this thread. */
 	set_speaking_thread_parameters();
@@ -921,29 +927,29 @@ static void *_ibmtts_synth(void *nothing)
 	/* Allocate a place for index mark names to be placed. */
 	char *mark_name = NULL;
 
-	while (!ibmtts_thread_exit_requested) {
+	while (!thread_exit_requested) {
 		/* If semaphore not set, set suspended lock and suspend until it is signaled. */
-		if (0 != sem_trywait(&ibmtts_synth_semaphore)) {
-			pthread_mutex_lock(&ibmtts_synth_suspended_mutex);
-			sem_wait(&ibmtts_synth_semaphore);
-			pthread_mutex_unlock(&ibmtts_synth_suspended_mutex);
-			if (ibmtts_thread_exit_requested)
+		if (0 != sem_trywait(&synth_semaphore)) {
+			pthread_mutex_lock(&synth_suspended_mutex);
+			sem_wait(&synth_semaphore);
+			pthread_mutex_unlock(&synth_suspended_mutex);
+			if (thread_exit_requested)
 				break;
 		}
-		DBG("Ibmtts: Synthesis semaphore on.");
+		DBG(DBG_MODNAME "Synthesis semaphore on.");
 
 		/* This table assigns each index mark name an integer id for fast lookup when
 		   ECI returns the integer index mark event. */
-		if (ibmtts_index_mark_ht)
-			g_hash_table_destroy(ibmtts_index_mark_ht);
-		ibmtts_index_mark_ht =
+		if (index_mark_ht)
+			g_hash_table_destroy(index_mark_ht);
+		index_mark_ht =
 		    g_hash_table_new_full(g_int_hash, g_int_equal, g_free,
 					  g_free);
 
-		pos = *ibmtts_message;
-		ibmtts_load_user_dictionary();
+		pos = *message;
+		load_user_dictionary();
 
-		switch (ibmtts_message_type) {
+		switch (message_type) {
 		case SPD_MSGTYPE_TEXT:
 			eciSetParam(eciHandle, eciTextMode, eciTextModeDefault);
 			break;
@@ -951,18 +957,18 @@ static void *_ibmtts_synth(void *nothing)
 			/* IBM TTS does not support sound icons.
 			   If we can find a sound icon file, play that,
 			   otherwise speak the name of the sound icon. */
-			part = ibmtts_search_for_sound_icon(*ibmtts_message);
+			part = search_for_sound_icon(*message);
 			if (NULL != part) {
-				ibmtts_add_flag_to_playback_queue
-				    (IBMTTS_QET_BEGIN);
-				ibmtts_add_sound_icon_to_playback_queue(part);
+				add_flag_to_playback_queue
+				    (QET_BEGIN);
+				add_sound_icon_to_playback_queue(part);
 				part = NULL;
-				ibmtts_add_flag_to_playback_queue
-				    (IBMTTS_QET_END);
+				add_flag_to_playback_queue
+				    (QET_END);
 				/* Wake up the audio playback thread, if not already awake. */
 				if (!is_thread_busy
-				    (&ibmtts_play_suspended_mutex))
-					sem_post(&ibmtts_play_semaphore);
+				    (&play_suspended_mutex))
+					sem_post(&play_semaphore);
 				continue;
 			} else
 				eciSetParam(eciHandle, eciTextMode,
@@ -975,11 +981,11 @@ static void *_ibmtts_synth(void *nothing)
 		case SPD_MSGTYPE_KEY:
 			/* TODO: make sure all SSIP cases are supported */
 			/* Map unspeakable keys to speakable words. */
-			DBG("Ibmtts: Key from Speech Dispatcher: |%s|", pos);
-			pos = ibmtts_subst_keys(pos);
-			DBG("Ibmtts: Key to speak: |%s|", pos);
-			g_free(*ibmtts_message);
-			*ibmtts_message = pos;
+			DBG(DBG_MODNAME "Key from Speech Dispatcher: |%s|", pos);
+			pos = subst_keys(pos);
+			DBG(DBG_MODNAME "Key to speak: |%s|", pos);
+			g_free(*message);
+			*message = pos;
 			eciSetParam(eciHandle, eciTextMode, eciTextModeDefault);
 			break;
 		case SPD_MSGTYPE_SPELL:
@@ -992,10 +998,10 @@ static void *_ibmtts_synth(void *nothing)
 			break;
 		}
 
-		ibmtts_add_flag_to_playback_queue(IBMTTS_QET_BEGIN);
+		add_flag_to_playback_queue(QET_BEGIN);
 		while (TRUE) {
-			if (ibmtts_stop_synth_requested) {
-				DBG("Ibmtts: Stop in synthesis thread, terminating.");
+			if (stop_synth_requested) {
+				DBG(DBG_MODNAME "Stop in synthesis thread, terminating.");
 				break;
 			}
 
@@ -1008,9 +1014,9 @@ static void *_ibmtts_synth(void *nothing)
 			   RECOGN_ICON = 2
 			 */
 
-			part = ibmtts_next_part(pos, &mark_name);
+			part = next_part(pos, &mark_name);
 			if (NULL == part) {
-				DBG("Ibmtts: Error getting next part of message.");
+				DBG(DBG_MODNAME "Error getting next part of message.");
 				/* TODO: What to do here? */
 				break;
 			}
@@ -1027,13 +1033,14 @@ static void *_ibmtts_synth(void *nothing)
 		}
 	}
 
-	DBG("Ibmtts: Synthesis thread ended.......\n");
+	DBG(DBG_MODNAME "Synthesis thread ended.......\n");
 
 	pthread_exit(NULL);
 }
 
-static void ibmtts_set_rate(signed int rate)
+static void set_rate(signed int rate)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	/* Setting rate to midpoint is too fast.  An eci value of 50 is "normal".
 	   See chart on pg 38 of the ECI manual. */
 	assert(rate >= -100 && rate <= +100);
@@ -1041,24 +1048,25 @@ static void ibmtts_set_rate(signed int rate)
 	/* Possible ECI range is 0 to 250. */
 	/* Map rate -100 to 100 onto speed 0 to 140. */
 	if (rate < 0)
-		/* Map -100 to 0 onto 0 to ibmtts_voice_speed */
-		speed = ((float)(rate + 100) * ibmtts_voice_speed) / (float)100;
+		/* Map -100 to 0 onto 0 to voice_speed */
+		speed = ((float)(rate + 100) * voice_speed) / (float)100;
 	else
-		/* Map 0 to 100 onto ibmtts_voice_speed to 140 */
+		/* Map 0 to 100 onto voice_speed to 140 */
 		speed =
-		    (((float)rate * (140 - ibmtts_voice_speed)) / (float)100)
-		    + ibmtts_voice_speed;
+		    (((float)rate * (140 - voice_speed)) / (float)100)
+		    + voice_speed;
 	assert(speed >= 0 && speed <= 140);
 	int ret = eciSetVoiceParam(eciHandle, 0, eciSpeed, speed);
 	if (-1 == ret) {
-		DBG("Ibmtts: Error setting rate %i.", speed);
-		ibmtts_log_eci_error();
+		DBG(DBG_MODNAME "Error setting rate %i.", speed);
+		log_eci_error();
 	} else
-		DBG("Ibmtts: Rate set to %i.", speed);
+		DBG(DBG_MODNAME "Rate set to %i.", speed);
 }
 
-static void ibmtts_set_volume(signed int volume)
+static void set_volume(signed int volume)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	/* Setting volume to midpoint makes speech too soft.  An eci value
 	   of 90 to 100 is "normal".
 	   See chart on pg 38 of the ECI manual.
@@ -1075,14 +1083,15 @@ static void ibmtts_set_volume(signed int volume)
 	assert(vol >= 0 && vol <= 100);
 	int ret = eciSetVoiceParam(eciHandle, 0, eciVolume, vol);
 	if (-1 == ret) {
-		DBG("Ibmtts: Error setting volume %i.", vol);
-		ibmtts_log_eci_error();
+		DBG(DBG_MODNAME "Error setting volume %i.", vol);
+		log_eci_error();
 	} else
-		DBG("Ibmtts: Volume set to %i.", vol);
+		DBG(DBG_MODNAME "Volume set to %i.", vol);
 }
 
-static void ibmtts_set_pitch(signed int pitch)
+static void set_pitch(signed int pitch)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	/* Setting pitch to midpoint is to low.  eci values between 65 and 89
 	   are "normal".
 	   See chart on pg 38 of the ECI manual. */
@@ -1090,28 +1099,29 @@ static void ibmtts_set_pitch(signed int pitch)
 	int pitchBaseline;
 	/* Possible range 0 to 100. */
 	if (pitch < 0)
-		/* Map -100 to 0 onto 0 to ibmtts_voice_pitch_baseline */
+		/* Map -100 to 0 onto 0 to voice_pitch_baseline */
 		pitchBaseline =
-		    ((float)(pitch + 100) * ibmtts_voice_pitch_baseline) /
+		    ((float)(pitch + 100) * voice_pitch_baseline) /
 		    (float)100;
 	else
-		/* Map 0 to 100 onto ibmtts_voice_pitch_baseline to 100 */
+		/* Map 0 to 100 onto voice_pitch_baseline to 100 */
 		pitchBaseline =
-		    (((float)pitch * (100 - ibmtts_voice_pitch_baseline)) /
+		    (((float)pitch * (100 - voice_pitch_baseline)) /
 		     (float)100)
-		    + ibmtts_voice_pitch_baseline;
+		    + voice_pitch_baseline;
 	assert(pitchBaseline >= 0 && pitchBaseline <= 100);
 	int ret =
 	    eciSetVoiceParam(eciHandle, 0, eciPitchBaseline, pitchBaseline);
 	if (-1 == ret) {
-		DBG("Ibmtts: Error setting pitch %i.", pitchBaseline);
-		ibmtts_log_eci_error();
+		DBG(DBG_MODNAME "Error setting pitch %i.", pitchBaseline);
+		log_eci_error();
 	} else
-		DBG("Ibmtts: Pitch set to %i.", pitchBaseline);
+		DBG(DBG_MODNAME "Pitch set to %i.", pitchBaseline);
 }
 
-static void ibmtts_set_punctuation_mode(SPDPunctuation punct_mode)
+static void set_punctuation_mode(SPDPunctuation punct_mode)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	const char *fmt = " `Pf%d%s ";
 	char *msg = NULL;
 	int real_punct_mode = 0;
@@ -1137,11 +1147,12 @@ static void ibmtts_set_punctuation_mode(SPDPunctuation punct_mode)
 	g_free(msg);
 }
 
-static char *ibmtts_voice_enum_to_str(SPDVoiceType voice)
+static char *voice_enum_to_str(SPDVoiceType voice_type)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	/* TODO: Would be better to move this to module_utils.c. */
 	char *voicename;
-	switch (voice) {
+	switch (voice_type) {
 	case SPD_MALE1:
 		voicename = g_strdup("male1");
 		break;
@@ -1175,32 +1186,32 @@ static char *ibmtts_voice_enum_to_str(SPDVoiceType voice)
 
 /* Given a language, dialect and SD voice codes sets the IBM voice */
 static void
-ibmtts_set_language_and_voice(char *lang, SPDVoiceType voice, char *variant)
+set_language_and_voice(char *lang, SPDVoiceType voice_type, char *variant)
 {
 	char *variant_name = variant;
-	char *voicename = ibmtts_voice_enum_to_str(voice);
+	char *voicename = voice_enum_to_str(voice_type);
 	int eciVoice;
 	int ret = -1;
 	int i = 0;
 	int j = 0;
 
-	DBG("Ibmtts: %s, lang=%s, voice=%d, dialect=%s",
-	    __FUNCTION__, lang, (int)voice, variant ? variant : NULL);
+	DBG(DBG_MODNAME "%s, lang=%s, voice_type=%d, dialect=%s",
+	    __FUNCTION__, lang, (int)voice_type, variant ? variant : NULL);
 
-	SPDVoice **v = ibmtts_voice_list;
+	SPDVoice **v = speechd_voice;
 	assert(v);
 
 	if (variant_name) {
 		for (i = 0; v[i]; i++) {
 			DBG("%d. variant=%s", i, v[i]->variant);
 			if (!strcmp(v[i]->variant, variant_name)) {
-				j = ibmtts_voice_index[i];
+				j = speechd_voice_index[i];
 				ret =
 				    eciSetParam(eciHandle, eciLanguageDialect,
 						eciLocales[j].langID);
-				DBG("Ibmtts: set langID=0x%x (ret=%d)",
+				DBG(DBG_MODNAME "set langID=0x%x (ret=%d)",
 				    eciLocales[j].langID, ret);
-				ibmtts_input_encoding = eciLocales[j].charset;
+				input_encoding = eciLocales[j].charset;
 				break;
 			}
 		}
@@ -1208,22 +1219,22 @@ ibmtts_set_language_and_voice(char *lang, SPDVoiceType voice, char *variant)
 		for (i = 0; v[i]; i++) {
 			DBG("%d. language=%s", i, v[i]->language);
 			if (!strcmp(v[i]->language, lang)) {
-				j = ibmtts_voice_index[i];
+				j = speechd_voice_index[i];
 				variant_name = v[i]->name;
 				ret =
 				    eciSetParam(eciHandle, eciLanguageDialect,
 						eciLocales[j].langID);
-				DBG("Ibmtts: set langID=0x%x (ret=%d)",
+				DBG(DBG_MODNAME "set langID=0x%x (ret=%d)",
 				    eciLocales[j].langID, ret);
-				ibmtts_input_encoding = eciLocales[j].charset;
+				input_encoding = eciLocales[j].charset;
 				break;
 			}
 		}
 	}
 
 	if (-1 == ret) {
-		DBG("Ibmtts: Unable to set language");
-		ibmtts_log_eci_error();
+		DBG(DBG_MODNAME "Unable to set language");
+		log_eci_error();
 	} else {
 		g_atomic_int_set(&locale_index_atomic, j);
 	}
@@ -1232,9 +1243,9 @@ ibmtts_set_language_and_voice(char *lang, SPDVoiceType voice, char *variant)
 	TIbmttsVoiceParameters *params =
 	    g_hash_table_lookup(IbmttsVoiceParameters, voicename);
 	if (NULL == params) {
-		DBG("Ibmtts: Setting default VoiceParameters for voice %s",
-		    voicename);
-		switch (voice) {
+		DBG(DBG_MODNAME "Setting default VoiceParameters for voice %s", voicename);
+
+		switch (voice_type) {
 		case SPD_MALE1:
 			eciVoice = 1;
 			break;	/* Adult Male 1 */
@@ -1265,73 +1276,74 @@ ibmtts_set_language_and_voice(char *lang, SPDVoiceType voice, char *variant)
 		}
 		ret = eciCopyVoice(eciHandle, eciVoice, 0);
 		if (-1 == ret)
-			DBG("Ibmtts: ERROR: Setting default voice parameters (voice %i).", eciVoice);
+			DBG(DBG_MODNAME "ERROR: Setting default voice parameters (voice %i).", eciVoice);
 	} else {
-		DBG("Ibmtts: Setting custom VoiceParameters for voice %s",
+		DBG(DBG_MODNAME "Setting custom VoiceParameters for voice %s",
 		    voicename);
 		ret = eciSetVoiceParam(eciHandle, 0, eciGender, params->gender);
 		if (-1 == ret)
-			DBG("Ibmtts: ERROR: Setting gender %i", params->gender);
+			DBG(DBG_MODNAME "ERROR: Setting gender %i", params->gender);
 		ret =
 		    eciSetVoiceParam(eciHandle, 0, eciBreathiness,
 				     params->breathiness);
 		if (-1 == ret)
-			DBG("Ibmtts: ERROR: Setting breathiness %i",
+			DBG(DBG_MODNAME "ERROR: Setting breathiness %i",
 			    params->breathiness);
 		ret =
 		    eciSetVoiceParam(eciHandle, 0, eciHeadSize,
 				     params->head_size);
 		if (-1 == ret)
-			DBG("Ibmtts: ERROR: Setting head size %i",
+			DBG(DBG_MODNAME "ERROR: Setting head size %i",
 			    params->head_size);
 		ret =
 		    eciSetVoiceParam(eciHandle, 0, eciPitchBaseline,
 				     params->pitch_baseline);
 		if (-1 == ret)
-			DBG("Ibmtts: ERROR: Setting pitch baseline %i",
+			DBG(DBG_MODNAME "ERROR: Setting pitch baseline %i",
 			    params->pitch_baseline);
 		ret =
 		    eciSetVoiceParam(eciHandle, 0, eciPitchFluctuation,
 				     params->pitch_fluctuation);
 		if (-1 == ret)
-			DBG("Ibmtts: ERROR: Setting pitch fluctuation %i",
+			DBG(DBG_MODNAME "ERROR: Setting pitch fluctuation %i",
 			    params->pitch_fluctuation);
 		ret =
 		    eciSetVoiceParam(eciHandle, 0, eciRoughness,
 				     params->roughness);
 		if (-1 == ret)
-			DBG("Ibmtts: ERROR: Setting roughness %i",
+			DBG(DBG_MODNAME "ERROR: Setting roughness %i",
 			    params->roughness);
 		ret = eciSetVoiceParam(eciHandle, 0, eciSpeed, params->speed);
 		if (-1 == ret)
-			DBG("Ibmtts: ERROR: Setting speed %i", params->speed);
+			DBG(DBG_MODNAME "ERROR: Setting speed %i", params->speed);
 	}
 	g_free(voicename);
 	/* Retrieve the baseline pitch and speed of the voice. */
-	ibmtts_voice_pitch_baseline =
-	    eciGetVoiceParam(eciHandle, 0, eciPitchBaseline);
-	if (-1 == ibmtts_voice_pitch_baseline)
-		DBG("Ibmtts: Cannot get pitch baseline of voice.");
-	ibmtts_voice_speed = eciGetVoiceParam(eciHandle, 0, eciSpeed);
-	if (-1 == ibmtts_voice_speed)
-		DBG("Ibmtts: Cannot get speed of voice.");
+	voice_pitch_baseline = eciGetVoiceParam(eciHandle, 0, eciPitchBaseline);
+	if (-1 == voice_pitch_baseline)
+		DBG(DBG_MODNAME "Cannot get pitch baseline of voice.");
+
+	voice_speed = eciGetVoiceParam(eciHandle, 0, eciSpeed);
+	if (-1 == voice_speed)
+		DBG(DBG_MODNAME "Cannot get speed of voice.");
 }
 
-static void ibmtts_set_voice(SPDVoiceType voice)
+static void set_voice_type(SPDVoiceType voice_type)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	if (msg_settings.voice.language) {
-		ibmtts_set_language_and_voice(msg_settings.voice.language,
-					      voice, NULL);
+		set_language_and_voice(msg_settings.voice.language, voice_type, NULL);
 	}
 }
 
-static void ibmtts_set_language(char *lang)
+static void set_language(char *lang)
 {
-	ibmtts_set_language_and_voice(lang, msg_settings.voice_type, NULL);
+	DBG(DBG_MODNAME "ENTER %s", __func__);
+	set_language_and_voice(lang, msg_settings.voice_type, NULL);
 }
 
 /* sets the IBM voice according to its name. */
-static void ibmtts_set_synthesis_voice(char *synthesis_voice)
+static void set_synthesis_voice(char *synthesis_voice)
 {
 	int i = 0;
 
@@ -1339,11 +1351,11 @@ static void ibmtts_set_synthesis_voice(char *synthesis_voice)
 		return;
 	}
 
-	DBG("Ibmtts: %s, synthesis voice=%s", __FUNCTION__, synthesis_voice);
+	DBG(DBG_MODNAME "ENTER %s(%s)", __FUNCTION__, synthesis_voice);
 
 	for (i = 0; i < MAX_NB_OF_LANGUAGES; i++) {
 		if (!strcasecmp(eciLocales[i].name, synthesis_voice)) {
-			ibmtts_set_language_and_voice(eciLocales[i].lang,
+			set_language_and_voice(eciLocales[i].lang,
 						      msg_settings.voice_type,
 						      eciLocales[i].variant);
 			break;
@@ -1352,12 +1364,13 @@ static void ibmtts_set_synthesis_voice(char *synthesis_voice)
 
 }
 
-static void ibmtts_log_eci_error()
+static void log_eci_error()
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	/* TODO: This routine is not working.  Not sure why. */
 	char buf[100];
 	eciErrorMessage(eciHandle, buf);
-	DBG("Ibmtts: ECI Error Message: %s", buf);
+	DBG(DBG_MODNAME "ECI Error Message: %s", buf);
 }
 
 /* IBM TTS calls back here when a chunk of audio is ready or an index mark
@@ -1368,33 +1381,33 @@ static enum ECICallbackReturn eciCallback(ECIHand hEngine,
 					  long lparam, void *data)
 {
 	/* This callback is running in the same thread as called eciSynchronize(),
-	   i.e., the _ibmtts_synth() thread. */
+	   i.e., the _synth() thread. */
 
 	/* If module_stop was called, discard any further callbacks until module_speak is called. */
-	if (ibmtts_stop_synth_requested || ibmtts_stop_play_requested)
+	if (stop_synth_requested || stop_play_requested)
 		return eciDataProcessed;
 
 	switch (msg) {
 	case eciWaveformBuffer:
-		DBG("Ibmtts: %ld audio samples returned from IBM TTS.", lparam);
+		DBG(DBG_MODNAME "%ld audio samples returned from TTS.", lparam);
 		/* Add audio to output queue. */
-		ibmtts_add_audio_to_playback_queue(audio_chunk, lparam);
+		add_audio_to_playback_queue(audio_chunk, lparam);
 		/* Wake up the audio playback thread, if not already awake. */
-		if (!is_thread_busy(&ibmtts_play_suspended_mutex))
-			sem_post(&ibmtts_play_semaphore);
+		if (!is_thread_busy(&play_suspended_mutex))
+			sem_post(&play_semaphore);
 		return eciDataProcessed;
 		break;
 	case eciIndexReply:
-		DBG("Ibmtts: Index mark id %ld returned from IBM TTS.", lparam);
-		if (lparam == IBMTTS_MSG_END_MARK) {
-			ibmtts_add_flag_to_playback_queue(IBMTTS_QET_END);
+		DBG(DBG_MODNAME "Index mark id %ld returned from TTS.", lparam);
+		if (lparam == MSG_END_MARK) {
+			add_flag_to_playback_queue(QET_END);
 		} else {
 			/* Add index mark to output queue. */
-			ibmtts_add_mark_to_playback_queue(lparam);
+			add_mark_to_playback_queue(lparam);
 		}
 		/* Wake up the audio playback thread, if not already awake. */
-		if (!is_thread_busy(&ibmtts_play_suspended_mutex))
-			sem_post(&ibmtts_play_semaphore);
+		if (!is_thread_busy(&play_suspended_mutex))
+			sem_post(&play_semaphore);
 		return eciDataProcessed;
 		break;
 	default:
@@ -1403,15 +1416,14 @@ static enum ECICallbackReturn eciCallback(ECIHand hEngine,
 }
 
 /* Adds a chunk of pcm audio to the audio playback queue. */
-static TIbmttsBool
-ibmtts_add_audio_to_playback_queue(TEciAudioSamples * audio_chunk,
-				   long num_samples)
+static gboolean add_audio_to_playback_queue(TEciAudioSamples * audio_chunk, long num_samples)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	TPlaybackQueueEntry *playback_queue_entry =
 	    (TPlaybackQueueEntry *) g_malloc(sizeof(TPlaybackQueueEntry));
 	if (NULL == playback_queue_entry)
-		return IBMTTS_FALSE;
-	playback_queue_entry->type = IBMTTS_QET_AUDIO;
+		return FALSE;
+	playback_queue_entry->type = QET_AUDIO;
 	playback_queue_entry->data.audio.num_samples = (int)num_samples;
 	int wlen = sizeof(TEciAudioSamples) * num_samples;
 	playback_queue_entry->data.audio.audio_chunk =
@@ -1420,63 +1432,65 @@ ibmtts_add_audio_to_playback_queue(TEciAudioSamples * audio_chunk,
 	pthread_mutex_lock(&playback_queue_mutex);
 	playback_queue = g_slist_append(playback_queue, playback_queue_entry);
 	pthread_mutex_unlock(&playback_queue_mutex);
-	return IBMTTS_TRUE;
+	return TRUE;
 }
 
 /* Adds an Index Mark to the audio playback queue. */
-static TIbmttsBool ibmtts_add_mark_to_playback_queue(long markId)
+static gboolean add_mark_to_playback_queue(long markId)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	TPlaybackQueueEntry *playback_queue_entry =
 	    (TPlaybackQueueEntry *) g_malloc(sizeof(TPlaybackQueueEntry));
 	if (NULL == playback_queue_entry)
-		return IBMTTS_FALSE;
-	playback_queue_entry->type = IBMTTS_QET_INDEX_MARK;
+		return FALSE;
+	playback_queue_entry->type = QET_INDEX_MARK;
 	playback_queue_entry->data.markId = markId;
 	pthread_mutex_lock(&playback_queue_mutex);
 	playback_queue = g_slist_append(playback_queue, playback_queue_entry);
 	pthread_mutex_unlock(&playback_queue_mutex);
-	return IBMTTS_TRUE;
+	return TRUE;
 }
 
 /* Adds a begin or end flag to the playback queue. */
-static TIbmttsBool
-ibmtts_add_flag_to_playback_queue(EPlaybackQueueEntryType type)
+static gboolean add_flag_to_playback_queue(EPlaybackQueueEntryType type)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	TPlaybackQueueEntry *playback_queue_entry =
 	    (TPlaybackQueueEntry *) g_malloc(sizeof(TPlaybackQueueEntry));
 	if (NULL == playback_queue_entry)
-		return IBMTTS_FALSE;
+		return FALSE;
 	playback_queue_entry->type = type;
 	pthread_mutex_lock(&playback_queue_mutex);
 	playback_queue = g_slist_append(playback_queue, playback_queue_entry);
 	pthread_mutex_unlock(&playback_queue_mutex);
-	return IBMTTS_TRUE;
+	return TRUE;
 }
 
 /* Add a sound icon to the playback queue. */
-static TIbmttsBool ibmtts_add_sound_icon_to_playback_queue(char *filename)
+static gboolean add_sound_icon_to_playback_queue(char *filename)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	TPlaybackQueueEntry *playback_queue_entry =
 	    (TPlaybackQueueEntry *) g_malloc(sizeof(TPlaybackQueueEntry));
 	if (NULL == playback_queue_entry)
-		return IBMTTS_FALSE;
-	playback_queue_entry->type = IBMTTS_QET_SOUND_ICON;
+		return FALSE;
+	playback_queue_entry->type = QET_SOUND_ICON;
 	playback_queue_entry->data.sound_icon_filename = filename;
 	pthread_mutex_lock(&playback_queue_mutex);
 	playback_queue = g_slist_append(playback_queue, playback_queue_entry);
 	pthread_mutex_unlock(&playback_queue_mutex);
-	return IBMTTS_TRUE;
+	return TRUE;
 }
 
 /* Deletes an entry from the playback audio queue, freeing memory. */
-static void
-ibmtts_delete_playback_queue_entry(TPlaybackQueueEntry * playback_queue_entry)
+static void delete_playback_queue_entry(TPlaybackQueueEntry * playback_queue_entry)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	switch (playback_queue_entry->type) {
-	case IBMTTS_QET_AUDIO:
+	case QET_AUDIO:
 		g_free(playback_queue_entry->data.audio.audio_chunk);
 		break;
-	case IBMTTS_QET_SOUND_ICON:
+	case QET_SOUND_ICON:
 		g_free(playback_queue_entry->data.sound_icon_filename);
 		break;
 	default:
@@ -1486,13 +1500,14 @@ ibmtts_delete_playback_queue_entry(TPlaybackQueueEntry * playback_queue_entry)
 }
 
 /* Erases the entire playback queue, freeing memory. */
-static void ibmtts_clear_playback_queue()
+static void clear_playback_queue()
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	pthread_mutex_lock(&playback_queue_mutex);
 	while (NULL != playback_queue) {
 		TPlaybackQueueEntry *playback_queue_entry =
 		    playback_queue->data;
-		ibmtts_delete_playback_queue_entry(playback_queue_entry);
+		delete_playback_queue_entry(playback_queue_entry);
 		playback_queue =
 		    g_slist_remove(playback_queue, playback_queue->data);
 	}
@@ -1501,9 +1516,9 @@ static void ibmtts_clear_playback_queue()
 }
 
 /* Sends a chunk of audio to the audio player and waits for completion or error. */
-static TIbmttsBool
-ibmtts_send_to_audio(TPlaybackQueueEntry * playback_queue_entry)
+static gboolean send_to_audio(TPlaybackQueueEntry * playback_queue_entry)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	AudioTrack track;
 #if defined(BYTE_ORDER) && (BYTE_ORDER == BIG_ENDIAN)
 	AudioFormat format = SPD_AUDIO_BE;
@@ -1519,41 +1534,42 @@ ibmtts_send_to_audio(TPlaybackQueueEntry * playback_queue_entry)
 	track.samples = playback_queue_entry->data.audio.audio_chunk;
 
 	if (track.samples == NULL)
-		return IBMTTS_TRUE;
+		return TRUE;
 
-	DBG("Ibmtts: Sending %i samples to audio.", track.num_samples);
+	DBG(DBG_MODNAME "Sending %i samples to audio.", track.num_samples);
 	ret = module_tts_output(track, format);
 	if (ret < 0) {
 		DBG("ERROR: Can't play track for unknown reason.");
-		return IBMTTS_FALSE;
+		return FALSE;
 	}
-	DBG("Ibmtts: Sent to audio.");
-	return IBMTTS_TRUE;
+	DBG(DBG_MODNAME "Sent to audio.");
+	return TRUE;
 }
 
 /* Playback thread. */
-static void *_ibmtts_play(void *nothing)
+static void *_play(void *nothing)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	int markId;
 	char *mark_name;
 	TPlaybackQueueEntry *playback_queue_entry = NULL;
 
-	DBG("Ibmtts: Playback thread starting.......\n");
+	DBG(DBG_MODNAME "Playback thread starting.......\n");
 
 	/* Block all signals to this thread. */
 	set_speaking_thread_parameters();
 
-	while (!ibmtts_thread_exit_requested) {
+	while (!thread_exit_requested) {
 		/* If semaphore not set, set suspended lock and suspend until it is signaled. */
-		if (0 != sem_trywait(&ibmtts_play_semaphore)) {
-			pthread_mutex_lock(&ibmtts_play_suspended_mutex);
-			sem_wait(&ibmtts_play_semaphore);
-			pthread_mutex_unlock(&ibmtts_play_suspended_mutex);
+		if (0 != sem_trywait(&play_semaphore)) {
+			pthread_mutex_lock(&play_suspended_mutex);
+			sem_wait(&play_semaphore);
+			pthread_mutex_unlock(&play_suspended_mutex);
 		}
-		/* DBG("Ibmtts: Playback semaphore on."); */
+		/* DBG(DBG_MODNAME "Playback semaphore on."); */
 
-		while (!ibmtts_stop_play_requested
-		       && !ibmtts_thread_exit_requested) {
+		while (!stop_play_requested
+		       && !thread_exit_requested) {
 			pthread_mutex_lock(&playback_queue_mutex);
 			if (NULL != playback_queue) {
 				playback_queue_entry = playback_queue->data;
@@ -1566,64 +1582,65 @@ static void *_ibmtts_play(void *nothing)
 				break;
 
 			switch (playback_queue_entry->type) {
-			case IBMTTS_QET_AUDIO:
-				ibmtts_send_to_audio(playback_queue_entry);
+			case QET_AUDIO:
+				send_to_audio(playback_queue_entry);
 				break;
-			case IBMTTS_QET_INDEX_MARK:
+			case QET_INDEX_MARK:
 				/* Look up the index mark integer id in lookup table to
 				   find string name and emit that name. */
 				markId = playback_queue_entry->data.markId;
 				mark_name =
-				    g_hash_table_lookup(ibmtts_index_mark_ht,
+				    g_hash_table_lookup(index_mark_ht,
 							&markId);
 				if (NULL == mark_name) {
-					DBG("Ibmtts: markId %d returned by IBM TTS not found in lookup table.", markId);
+					DBG(DBG_MODNAME "markId %d returned by TTS not found in lookup table.", markId);
 				} else {
-					DBG("Ibmtts: reporting index mark |%s|.", mark_name);
+					DBG(DBG_MODNAME "reporting index mark |%s|.", mark_name);
 					module_report_index_mark(mark_name);
-					DBG("Ibmtts: index mark reported.");
+					DBG(DBG_MODNAME "index mark reported.");
 					/* If pause requested, wait for an end-of-sentence index mark. */
-					if (ibmtts_pause_requested) {
+					if (pause_requested) {
 						if (0 ==
 						    strncmp(mark_name,
 							    SD_MARK_BODY,
 							    SD_MARK_BODY_LEN)) {
-							DBG("Ibmtts: Pause requested in playback thread.  Stopping.");
-							ibmtts_stop_play_requested
-							    = IBMTTS_TRUE;
+							DBG(DBG_MODNAME "Pause requested in playback thread.  Stopping.");
+							stop_play_requested
+							    = TRUE;
 						}
 					}
 				}
 				break;
-			case IBMTTS_QET_SOUND_ICON:
+			case QET_SOUND_ICON:
 				module_play_file(playback_queue_entry->
 						 data.sound_icon_filename);
 				break;
-			case IBMTTS_QET_BEGIN:
+			case QET_BEGIN:
 				module_report_event_begin();
 				break;
-			case IBMTTS_QET_END:
+			case QET_END:
 				module_report_event_end();
 				break;
 			}
 
-			ibmtts_delete_playback_queue_entry
+			delete_playback_queue_entry
 			    (playback_queue_entry);
 			playback_queue_entry = NULL;
 		}
-		if (ibmtts_stop_play_requested)
-			DBG("Ibmtts: Stop or pause in playback thread.");
+		if (stop_play_requested)
+			DBG(DBG_MODNAME "Stop or pause in playback thread.");
 	}
 
-	DBG("Ibmtts: Playback thread ended.......\n");
+	DBG(DBG_MODNAME "Playback thread ended.......\n");
 
 	pthread_exit(NULL);
 }
 
 /* Replaces all occurrences of "from" with "to" in msg.
    Returns count of replacements. */
-static int ibmtts_replace(char *from, char *to, GString * msg)
+static int replace(char *from, char *to, GString * msg)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	int count = 0;
 	int pos;
 	int from_len = strlen(from);
@@ -1639,11 +1656,12 @@ static int ibmtts_replace(char *from, char *to, GString * msg)
 	return count;
 }
 
-static void ibmtts_subst_keys_cb(gpointer data, gpointer user_data)
+static void subst_keys_cb(gpointer data, gpointer user_data)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	TIbmttsKeySubstitution *key_subst = data;
 	GString *msg = user_data;
-	ibmtts_replace(key_subst->key, key_subst->newkey, msg);
+	replace(key_subst->key, key_subst->newkey, msg);
 }
 
 /* Given a Speech Dispatcher !KEY key sequence, replaces unspeakable
@@ -1651,8 +1669,9 @@ static void ibmtts_subst_keys_cb(gpointer data, gpointer user_data)
    The subsitutions come from the KEY NAME SUBSTITUTIONS section of the
    config file.
    Caller is responsible for freeing returned string. */
-static char *ibmtts_subst_keys(char *key)
+static char *subst_keys(char *key)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	GString *tmp = g_string_sized_new(30);
 	g_string_append(tmp, key);
 
@@ -1660,7 +1679,7 @@ static char *ibmtts_subst_keys(char *key)
 					      msg_settings.voice.language);
 
 	if (keyTable)
-		g_list_foreach(keyTable, ibmtts_subst_keys_cb, tmp);
+		g_list_foreach(keyTable, subst_keys_cb, tmp);
 
 	/* Hyphen hangs IBM TTS */
 	if (0 == strcmp(tmp->str, "-"))
@@ -1678,8 +1697,9 @@ static char *ibmtts_subst_keys(char *key)
    If you have installed the free(b)soft sound-icons package under
    Debian, then these assumptions are true, but what about other distros
    and OSes? */
-static char *ibmtts_search_for_sound_icon(const char *icon_name)
+static char *search_for_sound_icon(const char *icon_name)
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	char *fn = NULL;
 	if (0 == strlen(IbmttsSoundIconFolder))
 		return fn;
@@ -1716,61 +1736,62 @@ void alloc_voice_list()
 	if (eciGetAvailableLanguages(aLanguage, &nLanguages))
 		return;
 
-	ibmtts_voice_list = g_malloc((nLanguages + 1) * sizeof(SPDVoice *));
-	ibmtts_voice_index = g_malloc((nLanguages + 1) * sizeof(SPDVoice *));
-	if (!ibmtts_voice_list)
+	speechd_voice = g_malloc((nLanguages + 1) * sizeof(SPDVoice *));
+	speechd_voice_index = g_malloc((nLanguages + 1) * sizeof(SPDVoice *));
+	if (!speechd_voice)
 		return;
 
-	DBG("Ibmtts: nLanguages=%d/%lu", nLanguages, (unsigned long)MAX_NB_OF_LANGUAGES);
+	DBG(DBG_MODNAME "nLanguages=%d/%lu", nLanguages, (unsigned long)MAX_NB_OF_LANGUAGES);
 	for (i = 0; i < nLanguages; i++) {
 		/* look for the language name */
 		int j;
-		ibmtts_voice_list[i] = g_malloc(sizeof(SPDVoice));
+		speechd_voice[i] = g_malloc(sizeof(SPDVoice));
 
-		DBG("Ibmtts: aLanguage[%d]=0x%08x", i, aLanguage[i]);
+		DBG(DBG_MODNAME "aLanguage[%d]=0x%08x", i, aLanguage[i]);
 		for (j = 0; j < MAX_NB_OF_LANGUAGES; j++) {
-			DBG("Ibmtts: eciLocales[%d].langID=0x%08x", j,
+			DBG(DBG_MODNAME "eciLocales[%d].langID=0x%08x", j,
 			    eciLocales[j].langID);
 			if (eciLocales[j].langID == aLanguage[i]) {
-				ibmtts_voice_list[i]->name = eciLocales[j].name;
-				ibmtts_voice_list[i]->language =
+				speechd_voice[i]->name = eciLocales[j].name;
+				speechd_voice[i]->language =
 				    eciLocales[j].lang;
-				ibmtts_voice_list[i]->variant =
+				speechd_voice[i]->variant =
 				    eciLocales[j].variant;
-				ibmtts_voice_index[i] = j;
-				DBG("Ibmtts: alloc_voice_list %s",
-				    ibmtts_voice_list[i]->name);
+				speechd_voice_index[i] = j;
+				DBG(DBG_MODNAME "alloc_voice_list %s",
+				    speechd_voice[i]->name);
 				break;
 			}
 		}
 		assert(j < MAX_NB_OF_LANGUAGES);
 	}
-	ibmtts_voice_list[nLanguages] = NULL;
-	DBG("Ibmtts: LEAVE %s", __func__);
+	speechd_voice[nLanguages] = NULL;
+	DBG(DBG_MODNAME "LEAVE %s", __func__);
 }
 
 static void free_voice_list()
 {
 	int i = 0;
 
-	if (ibmtts_voice_index) {
-		g_free(ibmtts_voice_index);
-		ibmtts_voice_index = NULL;
+	if (speechd_voice_index) {
+		g_free(speechd_voice_index);
+		speechd_voice_index = NULL;
 	}
 
-	if (!ibmtts_voice_list)
+	if (!speechd_voice)
 		return;
 
-	for (i = 0; ibmtts_voice_list[i]; i++) {
-		g_free(ibmtts_voice_list[i]);
+	for (i = 0; speechd_voice[i]; i++) {
+		g_free(speechd_voice[i]);
 	}
 
-	g_free(ibmtts_voice_list);
-	ibmtts_voice_list = NULL;
+	g_free(speechd_voice);
+	speechd_voice = NULL;
 }
 
-static void ibmtts_load_user_dictionary()
+static void load_user_dictionary()
 {
+	DBG(DBG_MODNAME "ENTER %s", __func__);
 	GString *dirname = NULL;
 	GString *filename = NULL;
 	int i = 0;
@@ -1782,13 +1803,13 @@ static void ibmtts_load_user_dictionary()
 
 	new_index = g_atomic_int_get(&locale_index_atomic);
 	if (new_index >= MAX_NB_OF_LANGUAGES) {
-		DBG("Ibmtts: %s, unexpected index (0x%x)", __FUNCTION__,
+		DBG(DBG_MODNAME "%s, unexpected index (0x%x)", __FUNCTION__,
 		    new_index);
 		return;
 	}
 
 	if (old_index == new_index) {
-		DBG("Ibmtts: LEAVE %s, no change", __FUNCTION__);
+		DBG(DBG_MODNAME "LEAVE %s, no change", __FUNCTION__);
 		return;
 	}
 
@@ -1798,7 +1819,7 @@ static void ibmtts_load_user_dictionary()
 		*dash = '_';
 
 	if (eciDict) {
-		DBG("Ibmtts: delete old dictionary");
+		DBG(DBG_MODNAME "delete old dictionary");
 		eciDeleteDict(eciHandle, eciDict);
 	}
 	eciDict = eciNewDict(eciHandle);
@@ -1806,7 +1827,7 @@ static void ibmtts_load_user_dictionary()
 		old_index = new_index;
 	} else {
 		old_index = MAX_NB_OF_LANGUAGES;
-		DBG("Ibmtts: can't create new dictionary");
+		DBG(DBG_MODNAME "can't create new dictionary");
 		g_free(language);
 		return;
 	}
@@ -1820,7 +1841,7 @@ static void ibmtts_load_user_dictionary()
 		if (!g_file_test(dirname->str, G_FILE_TEST_IS_DIR)) {
 			g_string_printf(dirname, "%s", IbmttsDictionaryFolder);
 			if (!g_file_test(dirname->str, G_FILE_TEST_IS_DIR)) {
-				DBG("Ibmtts: %s is not a directory",
+				DBG(DBG_MODNAME "%s is not a directory",
 				    dirname->str);
 				g_free(language);
 				return;
@@ -1829,7 +1850,7 @@ static void ibmtts_load_user_dictionary()
 	}
 	g_free(language);
 
-	DBG("Ibmtts: Looking in dictionary directory %s", dirname->str);
+	DBG(DBG_MODNAME "Looking in dictionary directory %s", dirname->str);
 	filename = g_string_new(NULL);
 
 	for (i = 0; i < NB_OF_DICTIONARY_FILENAMES; i++) {
@@ -1840,14 +1861,14 @@ static void ibmtts_load_user_dictionary()
 			    eciLoadDict(eciHandle, eciDict, i, filename->str);
 			if (!error) {
 				dictionary_is_present = 1;
-				DBG("Ibmtts: %s dictionary loaded",
+				DBG(DBG_MODNAME "%s dictionary loaded",
 				    filename->str);
 			} else {
-				DBG("Ibmtts: Can't load %s dictionary (%d)",
+				DBG(DBG_MODNAME "Can't load %s dictionary (%d)",
 				    filename->str, error);
 			}
 		} else {
-			DBG("Ibmtts: No %s dictionary", filename->str);
+			DBG(DBG_MODNAME "No %s dictionary", filename->str);
 		}
 	}
 
@@ -1858,3 +1879,6 @@ static void ibmtts_load_user_dictionary()
 		eciSetDict(eciHandle, eciDict);
 	}
 }
+/* local variables: */
+/* c-basic-offset: 8 */
+/* end: */


### PR DESCRIPTION
This harmonizes the codestyle with the voxin module source:

- use gboolean/FALSE/TRUE
- drop ibtts_ prefixes
- Use DBG_MODNAME
- move update_sample_rate code.
- add DBG(DBG_MODNAME "ENTER %s", __func__);