### PR TITLE
doc/: Avoid cleaning html files

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -35,4 +35,7 @@ CLEANFILES = spd-say.info \
 	version-2.texi \
 	version.texi
 
+# Keep .html versions in the public web repository
+clean-aminfo:
+
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
We want to have .html files ready for read in the public web repository.

Fixes #394