### PR TITLE
Fix crash with python 3.9

### DIFF
--- a/src/api/python/speechd/client.py
+++ b/src/api/python/speechd/client.py
@@ -289,7 +289,7 @@ class _SSIP_Connection(object):
         and return the triplet (code, msg, data)."""
         # TODO: This check is dumb but seems to work.  The main thread
         # hangs without it, when the Speech Dispatcher connection is lost.
-        if not self._communication_thread.isAlive():
+        if not self._communication_thread.is_alive():
             raise SSIPCommunicationError
         self._ssip_reply_semaphore.acquire()
         # The list is sorted, read the first item


### PR DESCRIPTION
Thread.isAlive() was removed in python 3.9. Thread.is_alive() has been
available since python 2.6, so let's use that.

Fixes #402