### PR TITLE
ibmtts voxin: Fix speaking when SSML is disabled

### DIFF
--- a/src/modules/ibmtts.c
+++ b/src/modules/ibmtts.c
@@ -817,6 +817,14 @@ static void *_synth(void *nothing)
 		}
 
 		module_speak_queue_before_play();
+
+		if (!IbmttsUseSSML)
+		{
+			process_text_mark(pos, strlen(pos), NULL);
+			process_text_mark(NULL, 0, NULL);
+			continue;
+		}
+
 		while (TRUE) {
 			if (module_speak_queue_stop_requested()) {
 				DBG(DBG_MODNAME "Stop in synthesis thread, terminating.");


### PR DESCRIPTION
When SSML is disabled we turned SSML into raw text. We shall not process
it again, in case the client actually want to speak e.g. "<speak>".