### PR TITLE
voxin: set capitalization style (from cap_let_recogn)

### DIFF
--- a/src/modules/ibmtts.c
+++ b/src/modules/ibmtts.c
@@ -232,6 +232,7 @@ static void set_rate(signed int rate);
 static void set_pitch(signed int pitch);
 static void set_punctuation_mode(SPDPunctuation punct_mode);
 static void set_volume(signed int pitch);
+static void set_capital_mode(SPDCapitalLetters cap_mode);
 
 /* locale_index_atomic stores the current index of the voices or eciLocales array.
    The main thread writes this information, the synthesis thread reads it.
@@ -516,11 +517,8 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 	UPDATE_PARAMETER(volume, set_volume);
 	UPDATE_PARAMETER(pitch, set_pitch);
 	UPDATE_PARAMETER(punctuation_mode, set_punctuation_mode);
-
-	/* TODO: Handle these in _synth() ?
-	   UPDATE_PARAMETER(cap_let_recogn, festival_set_cap_let_recogn);
-	 */
-
+	UPDATE_PARAMETER(cap_let_recogn, set_capital_mode);
+	
 	if (!IbmttsUseSSML) {
 		/* Strip all SSML */
 		char *tmp = message;
@@ -998,6 +996,30 @@ static void set_punctuation_mode(SPDPunctuation punct_mode)
 	eciAddText(eciHandle, msg);
 	g_free(msg);
 }
+
+#ifdef VOXIN
+static void set_capital_mode(SPDCapitalLetters cap_mode)
+{
+	DBG(DBG_MODNAME "ENTER %s", __func__);
+	voxCapitalMode mode = voxCapitalNone;
+
+	switch (cap_mode) {
+	case SPD_CAP_NONE:
+		mode = voxCapitalNone;
+		break;
+	case SPD_CAP_SPELL:
+		mode = voxCapitalSpell;
+		break;
+	case SPD_CAP_ICON:
+		mode = voxCapitalSoundIcon;
+		break;
+	}
+
+	voxSetParam(eciHandle, VOX_CAPITALS, mode);
+}
+#else
+static void set_capital_mode(SPDCapitalLetters cap_mode){}
+#endif
 
 static char *voice_enum_to_str(SPDVoiceType voice_type)
 {

--- a/src/modules/voxin.h
+++ b/src/modules/voxin.h
@@ -1,15 +1,15 @@
 /*
   Copyright 2016-2020, Gilles Casse <gcasse@oralux.org>
 
-  This is free software; you can redistribute it and/or modify it under the
-  terms of the GNU Lesser General Public License as published by the Free
-  Software Foundation; either version 2.1, or (at your option) any later
-  version.
+  This is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1, or
+  (at your option) any later version.
 
-  This software is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  General Public License for more details.
+  This software is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
 
 */
 
@@ -22,9 +22,8 @@
    Voxin offers the following features:
    
    - a choice of voices among IBM TTS and Vocalizer Embedded,    
-   - complementary features added to the original proprietary text-to-speech. 
-   - compatibility of the legacy x86 IBM TTS binaries in an x86_64
-   environment,
+   - complementary features added to the original proprietary text-to-speech,
+   - compatibility of the legacy x86 IBM TTS binaries in an x86_64 environment.
    
    Links:
    - Libvoxin sources: https://github.com/Oralux/libvoxin 
@@ -41,7 +40,7 @@
 
 #define LIBVOXIN_VERSION_MAJOR 1
 #define LIBVOXIN_VERSION_MINOR 5
-#define LIBVOXIN_VERSION_PATCH 0
+#define LIBVOXIN_VERSION_PATCH 2
 
 /**
    @brief Extends ECIParam (eci.h)
@@ -62,9 +61,12 @@ typedef enum {
 
 typedef enum {voxFemale, voxMale} voxGender;
 typedef enum {voxAdult, voxChild, voxSenior} voxAge;
+typedef enum {voxCapitalNone=0, voxCapitalSoundIcon=1, voxCapitalSpell=2, voxCapitalPitch=3} voxCapitalMode;
 
 #define VOX_STR_MAX 128
+
 #define VOX_OK 0
+#define VOX_PARAM_OUT_OF_RANGE -1
 
 /**
    @brief Describe a voice.
@@ -129,19 +131,13 @@ int voxGetVoices(vox_t *list, unsigned int *nbVoices);
    * VOX_CAPITALS: define the action to execute with capital
    letters. Similar to espeakCAPITALS in the eSpeak API.
 
-   Expected value for VOX_CAPITALS:
-   0 = no action
-   1 = play a sound icon 
-   2 = spell the capital letter
-   3 or higher: raise pitch
-
-   By default the sound icon is /usr/share/sounds/sound-icons/capital
-   (provided by the sounds-icon package of your distribution).
+   Expected value for VOX_CAPITALS: see enum voxCapitalMode.
+   Value greater than voxCapitalPitch should be accepted and raise pitch.
 
    @param handle  instance created by eciNew() or eciNewEx()
    @param param
    @param value
-   @return int  VOX_OK on success
+   @return int  previous voxParam value on success, VOX_PARAM_OUT_OF_RANGE otherwise 
 */
 int voxSetParam(void *handle, voxParam param, int value);
 


### PR DESCRIPTION
Hi,
This patch has been checked with Voxin 3.2 (which may now insert sound icons/clicks) and speech-dispatcher 0.10.1 (voxin 3.2 includes a backport of this ibmtts voxin module). 
