### PR TITLE
Fix dot stuffing between core and modules

### DIFF
--- a/src/modules/module_utils.c
+++ b/src/modules/module_utils.c
@@ -57,7 +57,7 @@ char *module_index_mark;
 
 char *do_message(SPDMessageType msgtype)
 {
-	int ret;
+	int ret, offset;
 	char *cur_line;
 	GString *msg;
 	size_t n;
@@ -70,23 +70,27 @@ char *do_message(SPDMessageType msgtype)
 
 	while (1) {
 		cur_line = NULL;
+		offset = 0;
 		n = 0;
 		ret = spd_getline(&cur_line, &n, stdin);
 		nlines++;
 		if (ret == -1)
 			return g_strdup("401 ERROR INTERNAL");
 
-		if (!strcmp(cur_line, "..\n")) {
-			g_free(cur_line);
-			cur_line = g_strdup(".\n");
-		} else if (!strcmp(cur_line, ".\n")) {
+		if (!strcmp(cur_line, ".\n")) {
 			/* Strip the trailing \n */
 			msg->str[strlen(msg->str) - 1] = 0;
 			g_free(cur_line);
 			break;
 		}
+
+		if (cur_line[0] == '.') {
+			offset++;
+			cur_line++;
+		}
+
 		g_string_append(msg, cur_line);
-		g_free(cur_line);
+		g_free(cur_line - offset);
 	}
 
 	if ((msgtype != SPD_MSGTYPE_TEXT) && (nlines > 2)) {

--- a/src/server/output.c
+++ b/src/server/output.c
@@ -860,7 +860,6 @@ char *escape_dot(char *otext)
 	GString *ntext;
 	char *ootext;
 	char *ret = NULL;
-	int len;
 
 	if (otext == NULL)
 		return NULL;
@@ -871,41 +870,21 @@ char *escape_dot(char *otext)
 
 	ntext = g_string_new("");
 
-	if (strlen(otext) == 1) {
-		if (!strcmp(otext, ".")) {
-			g_string_append(ntext, "..");
-			otext += 1;
-		}
-	}
-
-	if (strlen(otext) >= 2) {
-		if ((otext[0] == '.') && (otext[1] == '\n')) {
-			g_string_append(ntext, "..\n");
-			otext = otext + 2;
-		}
+	if (otext[0] == '.') {
+		g_string_append(ntext, "..");
+		otext += 1;
 	}
 
 	MSG2(6, "escaping", "Altering text (I): |%s|", ntext->str);
 
-	while ((seq = strstr(otext, "\n.\n"))) {
+	while ((seq = strstr(otext, "\n."))) {
 		*seq = 0;
 		g_string_append(ntext, otext);
-		g_string_append(ntext, "\n..\n");
-		otext = seq + 3;
+		g_string_append(ntext, "\n..");
+		otext = seq + 2;
 	}
 
 	MSG2(6, "escaping", "Altering text (II): |%s|", ntext->str);
-
-	len = strlen(otext);
-	if (len >= 2) {
-		if ((otext[len - 2] == '\n') && (otext[len - 1] == '.')) {
-			g_string_append(ntext, otext);
-			g_string_append(ntext, ".");
-			otext = otext + len;
-			MSG2(6, "escaping", "Altering text (II-b): |%s|",
-			     ntext->str);
-		}
-	}
 
 	if (otext == ootext) {
 		g_string_free(ntext, 1);


### PR DESCRIPTION
SSIP uses the same dot stuffing as SMTP: any dot leading a line is to be
duplicated. Otherwise we would not be able to provide the ".." text to
the module, since it would be taken as ".".