### PR TITLE
Add DefaultVoice option for the generic module

### DIFF
--- a/config/modules/dtk-generic.conf
+++ b/config/modules/dtk-generic.conf
@@ -56,6 +56,11 @@ AddVoice	"en"	"FEMALE2"	"u"
 AddVoice	"en"	"FEMALE3"	"w"
 AddVoice	"en"	"CHILD_MALE"	"k"
 
+# DefaultVoice specifies which $VOICE string should be used if no voice is
+# specified otherwise.
+
+defaultVoice    "p"
+
 GenericLanguage	"en" "en"
 
 # These parameters set _rate_ and _pitch_ conversion. This is

--- a/config/modules/epos-generic.conf
+++ b/config/modules/epos-generic.conf
@@ -39,6 +39,11 @@ GenericSoundIconFolder "/usr/share/sounds/sound-icons/"
 AddVoice        "cs"	"male1"      "kadlec"
 AddVoice        "sk"	"male1"      "bob"
 
+# DefaultVoice specifies which $VOICE string should be used if no voice is
+# specified otherwise.
+
+defaultVoice    "kadlec"
+
 # If the language you need to pass in $LANG is different
 # from the standard ISO language code, you can specify
 # which string to use instead. If you wish to use

--- a/config/modules/espeak-mbrola-generic.conf
+++ b/config/modules/espeak-mbrola-generic.conf
@@ -163,6 +163,11 @@ AddVoice        "sv"    "FEMALE1"    	"sw2"
 AddVoice        "tr"    "MALE1"         "tr1"
 AddVoice        "tr"    "FEMALE1"       "tr2"
 
+# DefaultVoice specifies which $VOICE string should be used if no voice is
+# specified otherwise.
+
+DefaultVoice    "en1"
+
 # These parameters set _rate_, _pitch_, and _volume_ conversion. This is
 # part of the core of the definition of this generic output
 # module for this concrete synthesizer, it's not intended to
@@ -211,7 +216,7 @@ Debug 0
 
 # Copyright (C) 2008-2010 Brailcom, o.p.s
 # Copyright (C) 2014 Luke Yelavich <themuso@ubuntu.com>
-# Copyright (C) 2018-2020 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2018-2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
 # Copyright (C) 2018 Didier Spaier <didier@slint.fr>
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -191,6 +191,11 @@ AddVoice "lt" "MALE2" "lt2"
 
 Addvoice "ms" "FEMALE1" "ma1"
 
+# DefaultVoice specifies which $VOICE string should be used if no voice is
+# specified otherwise.
+
+DefaultVoice    "en1"
+
 # nl1 has a very limited set of diphones and is usable only for reading
 # numbers. Uncomment the next line if you want it.
 # AddVoice "nl" "CHILD-MALE" "nl1"
@@ -265,7 +270,7 @@ Debug 0
 
 # Copyright (C) 2008-2010 Brailcom, o.p.s
 # Copyright (C) 2014 Luke Yelavich <themuso@ubuntu.com>
-# Copyright (C) 2018-2020 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2018-2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
 # Copyright (C) 2018 Didier Spaier <didier@slint.fr>
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/config/modules/llia_phon-generic.conf
+++ b/config/modules/llia_phon-generic.conf
@@ -33,6 +33,11 @@ GenericSoundIconFolder "/usr/share/sounds/sound-icons/"
 AddVoice        "fr"	"male1"      "phoneme-file"
 AddVoice        "fr"	"male2"      "phoneme-file"
 
+# DefaultVoice specifies which $VOICE string should be used if no voice is
+# specified otherwise.
+
+DefaultVoice    "phoneme-file"
+
 GenericLanguage "fr" "fr"
 
 # These parameters set _rate_ and _pitch_ conversion. This is

--- a/config/modules/mary-generic.conf
+++ b/config/modules/mary-generic.conf
@@ -101,6 +101,11 @@ AddVoice        "it"    "FEMALE1"       "istc-lucia-hsmm"
 # Not installed yet
 #marylux-lb
 
+# DefaultVoice specifies which $VOICE string should be used if no voice is
+# specified otherwise.
+
+DefaultVoice    "dfki-spike"
+
 # These parameters set _rate_, _pitch_, and _volume_ conversion. This is
 # part of the core of the definition of this generic output
 # module for this concrete synthesizer, it's not intended to

--- a/config/modules/swift-generic.conf
+++ b/config/modules/swift-generic.conf
@@ -44,6 +44,11 @@ AddVoice	"en"	"FEMALE1" 	"Diane"
 AddVoice	"en"	"FEMALE2"	"Linda"
 AddVoice	"en"	"FEMALE3"	"Callie"
 
+# DefaultVoice specifies which $VOICE string should be used if no voice is
+# specified otherwise.
+
+DefaultVoice    "David"
+
 GenericLanguage "en" "en"
 
 # These parameters set _rate_ and _pitch_ conversion. This is

--- a/doc/speech-dispatcher.texi
+++ b/doc/speech-dispatcher.texi
@@ -808,6 +808,16 @@ this:
         AddVoice        "sk"  "male1"   "bob"
 @end example
 
+@item DefaultVoice "@var{name}"
+@anchor{DefaultVoice}
+
+If the client does not request for a particular voice, we should be still using
+some voice so that the user at least gets some feedback, even if in the wrong
+language. @code{DefaultVoice} can be used to specify which voice should be used
+in such a case. If not specified, the @code{no_voice} string is passed instead.
+
+@var{name} is a name specific for the given output module.
+
 @item ModuleDelimiters "@var{delimiters}", ModuleMaxChunkLength @var{length}
 
 Normally, the output module doesn't try to synthesize all

--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -473,10 +473,14 @@ void *_generic_speak(void *nothing)
 					e_string =
 					    string_replace(e_string, "$VOICE",
 							   generic_msg_voice_str);
-				else
+				else {
+					char *default_voice = module_getdefaultvoice();
+					if (!default_voice)
+						default_voice = "no_voice";
 					e_string =
 					    string_replace(e_string, "$VOICE",
-							   "no_voice");
+							    default_voice);
+				}
 
 				/* Cut it into two strings */
 				p = strstr(e_string, "$DATA");

--- a/src/modules/module_utils.h
+++ b/src/modules/module_utils.h
@@ -418,5 +418,6 @@ void module_register_available_voices(void);
 void module_register_settings_voices(void);
 char *module_getvoice(char *language, SPDVoiceType voice);
 gboolean module_existsvoice(char *voicename);
+char *module_getdefaultvoice(void);
 
 #endif /* #ifndef __MODULE_UTILS_H */

--- a/src/modules/module_utils_addvoice.c
+++ b/src/modules/module_utils_addvoice.c
@@ -37,6 +37,7 @@ static int nbvoices=0;
 static int nbpaths=0;
 static SPDVoice *generic_voices;
 static SPDVoice **generic_voices_list;
+static char *default_voice;
 static char **dependency_paths;
 typedef struct {
 	char *male1;
@@ -154,6 +155,21 @@ DOTCONF_CB(AddVoice_cb)
 	return NULL;
 }
 
+DOTCONF_CB(DefaultVoice_cb)
+{
+	char *voicename = cmd->data.list[0];
+	if (voicename == NULL) {
+		DBG("Missing default voice name\n");
+		return NULL;
+	}
+
+	if (default_voice)
+		free(default_voice);
+	default_voice = strdup(voicename);
+
+	return NULL;
+}
+
 void module_register_available_voices(void)
 {
 	module_dc_options = module_add_config_option(module_dc_options,
@@ -169,6 +185,10 @@ void module_register_settings_voices(void)
 						     &module_num_dc_options,
 						     "AddVoice", ARG_LIST,
 						     AddVoice_cb, NULL, 0);
+	module_dc_options = module_add_config_option(module_dc_options,
+						     &module_num_dc_options,
+						     "DefaultVoice", ARG_STR,
+						     DefaultVoice_cb, NULL, 0);
 }
 
 gboolean module_existsvoice(char *voicename)
@@ -254,4 +274,9 @@ char *module_getvoice(char *language, SPDVoiceType voice)
 		fprintf(stderr, "No voice available for this output module!");
 
 	return ret;
+}
+
+char *module_getdefaultvoice(void)
+{
+	return default_voice;
 }


### PR DESCRIPTION
We should avoid remaining silent even if the client does not even tell which
language should be spoken. Adding the DefaultVoice lets generic modules have
a default voice choice.