### PR TITLE
Make module_speak_sync have to call module_report_event_begin/end

### DIFF
--- a/src/modules/module_process.c
+++ b/src/modules/module_process.c
@@ -152,9 +152,7 @@ static void cmd_speak(int fd, SPDMessageType msgtype)
 #pragma weak module_speak
 	if (module_speak_sync) {
 		print("200 OK SPEAKING");
-		module_report_event_begin();
 		ret = module_speak_sync(text, text_len, msgtype);
-		module_report_event_end();
 	} else {
 		ret = module_speak(text, text_len, msgtype);
 		if (ret > 0)

--- a/src/modules/skeleton0.c
+++ b/src/modules/skeleton0.c
@@ -176,17 +176,23 @@ int module_loop(void)
 #if 1
 int module_speak_sync(char *data, size_t bytes, SPDMessageType msgtype)
 {
+	module_report_event_begin();
+
 	/* TODO: Speak the provided data synchronously */
 	fprintf(stderr, "speaking '%s'\n", data);
 
+	module_report_event_end();
 	return 1;
 }
 #else
 int module_speak(char *data, size_t bytes, SPDMessageType msgtype)
 {
+	module_report_event_begin();
+
 	/* TODO: Speak the provided data asynchronously */
 	fprintf(stderr, "speaking '%s'\n", data);
 
+	module_report_event_end();
 	return 1;
 }
 #endif

--- a/src/modules/skeleton0_espeak-ng0.c
+++ b/src/modules/skeleton0_espeak-ng0.c
@@ -221,6 +221,8 @@ int module_loop(void)
 
 int module_speak_sync(char *data, size_t bytes, SPDMessageType msgtype)
 {
+	module_report_event_begin();
+
 	/* TODO: Speak the provided data synchronously */
 	fprintf(stderr, "speaking '%s'\n", data);
 
@@ -229,6 +231,7 @@ int module_speak_sync(char *data, size_t bytes, SPDMessageType msgtype)
 		     NULL, NULL);
 	espeak_Synchronize();
 
+	module_report_event_end();
 	return 1;
 }
 

--- a/src/modules/skeleton_config.c
+++ b/src/modules/skeleton_config.c
@@ -100,17 +100,23 @@ static void skeleton_set_pitch(signed int pitch)
 #if 1
 int module_speak_sync(char *data, size_t bytes, SPDMessageType msgtype)
 {
+	module_report_event_begin();
+
 	/* TODO: Speak the provided data synchronously */
 	fprintf(stderr, "speaking '%s'\n", data);
 
 	/* Update synth parameters according to message parameters */
 	UPDATE_PARAMETER(rate, skeleton_set_rate);
 	UPDATE_PARAMETER(pitch, skeleton_set_pitch);
+
+	module_report_event_end();
 	return 1;
 }
 #else
 int module_speak(char *data, size_t bytes, SPDMessageType msgtype)
 {
+	module_report_event_begin();
+
 	/* TODO: Speak the provided data asynchronously */
 	fprintf(stderr, "speaking '%s'\n", data);
 
@@ -118,6 +124,7 @@ int module_speak(char *data, size_t bytes, SPDMessageType msgtype)
 	UPDATE_PARAMETER(rate, skeleton_set_rate);
 	UPDATE_PARAMETER(pitch, skeleton_set_pitch);
 
+	module_report_event_end();
 	return 1;
 }
 #endif


### PR DESCRIPTION
This allows modules to properly handle pause/stop with synchronized API.