### PR TITLE
Audio transfer: restore 705 AUDIO multi-line termination

### DIFF
--- a/src/modules/module_process.c
+++ b/src/modules/module_process.c
@@ -82,7 +82,7 @@ void module_tts_output_server(const AudioTrack *track, AudioFormat format)
 	printf("705-num_samples=%d\n", track->num_samples);
 	printf("705-big_endian=%d\n", format);
 
-	printf("705 AUDIO");
+	printf("705-AUDIO");
 	putc(0, stdout);
 
 	p = (const char *) track->samples;
@@ -118,6 +118,7 @@ void module_tts_output_server(const AudioTrack *track, AudioFormat format)
 		p = next;
 	}
 	putc('\n', stdout);
+	printf("705 AUDIO\n");
 
 	pthread_mutex_unlock(&module_stdout_mutex);
 	fflush(stdout);

--- a/src/server/output.c
+++ b/src/server/output.c
@@ -777,11 +777,6 @@ int output_module_is_speaking(OutputModule * output, char **index_mark)
 			}
 
 			while (1) {
-				if (strncmp(p, "705 AUDIO", strlen("705 AUDIO")) == 0 && p[strlen("705 AUDIO")] == '\0') {
-					p += strlen("705 AUDIO") + 1;
-					break;
-				}
-
 				if (strncmp(p, "705-", 4) != 0) {
 					MSG2(2, "output_module",
 						"ERROR: bogus audio parameter %s", p);
@@ -793,6 +788,11 @@ int output_module_is_speaking(OutputModule * output, char **index_mark)
 					MSG2(2, "output_module",
 						"ERROR: bogus audio end of line %s", p);
 					retcode = -5;
+					break;
+				}
+
+				if (strncmp(p, "705-AUDIO", strlen("705-AUDIO")) == 0 && p[strlen("705-AUDIO")] == '\0') {
+					p += strlen("705-AUDIO") + 1;
 					break;
 				}
 


### PR DESCRIPTION
The module protocol usually embeds data in the multi-line continuations,
not on the termination line.