### PR TITLE
server: Avoid getting stuck inside audio code

### DIFF
--- a/src/server/output.c
+++ b/src/server/output.c
@@ -918,7 +918,13 @@ int output_module_is_speaking(OutputModule * output, char **index_mark)
 				output->track = track;
 			}
 
-			if (spd_audio_feed_sync_overlap(output->audio, track, format) < 0) {
+			output_unlock();
+
+			int ret = spd_audio_feed_sync_overlap(output->audio, track, format);
+
+			output_lock();
+
+			if (ret < 0) {
 				MSG2(2, "output_module",
 					"Could not play audio");
 				free(track.samples);


### PR DESCRIPTION
We disable asynchronous canceling while holding the output mutex to avoid
deadlocks, but we want to be cancellable inside the audio rendering.