### PR TITLE
Move the speak queue to libcommon

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -23,7 +23,7 @@ libcommon_la_CFLAGS = $(ERROR_CFLAGS) $(GLIB_CFLAGS) \
 libcommon_la_CPPFLAGS = "-I$(top_srcdir)/include/" $(GLIB_CFLAGS) \
 	-DPLUGIN_DIR="\"$(audiodir)\""
 libcommon_la_LIBADD = $(GLIB_LIBS)
-libcommon_la_SOURCES = fdsetconv.c spd_getline.c i18n.c spd_audio.c spd_audio.h
+libcommon_la_SOURCES = common.c common.h fdsetconv.c spd_getline.c i18n.c spd_audio.c spd_audio.h speak_queue.c speak_queue.h
 
 
 -include $(top_srcdir)/git.mk

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -1,0 +1,40 @@
+/*
+ * common.c - Common utilities
+ * Copyright (C) 2003,2006, 2007 Brailcom, o.p.s.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1, or (at your option) any later
+ * version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <signal.h>
+#include <pthread.h>
+
+#include "common.h"
+
+void set_speaking_thread_parameters(void)
+{
+	int ret;
+	sigset_t all_signals;
+
+	ret = sigfillset(&all_signals);
+	if (ret == 0) {
+		ret = pthread_sigmask(SIG_BLOCK, &all_signals, NULL);
+		if (ret != 0)
+			MSG(1, "Can't set signal set, expect problems when terminating!\n");
+	} else {
+		MSG(1, "Can't fill signal set, expect problems when terminating!\n");
+	}
+
+	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
+	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+}

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -1,0 +1,46 @@
+
+/*
+ * common.h - Common declarations valid both in server and modules
+ *
+ * Copyright (C) 2001, 2002, 2003, 2006, 2007 Brailcom, o.p.s.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef _COMMON_H
+#define _COMMON_H 1
+
+/* Debugging */
+void MSG(int level, char *format, ...);
+void MSG2(int level, char *kind, char *format, ...);
+#define DBG(arg...) MSG(4, arg)
+
+void set_speaking_thread_parameters(void);
+
+/* This should be called when reaching a mark */
+void module_report_index_mark(char *mark);
+/* This should be called when beginning playing the speech */
+void module_report_event_begin(void);
+/* This should be called when finishing playing the speech */
+void module_report_event_end(void);
+/* This should be called when stopping the speech */
+void module_report_event_stop(void);
+/* This should be called when pausing the speech */
+void module_report_event_pause(void);
+/* This should be called when reaching a sound icon */
+void module_report_icon(const char *icon);
+/* This should be called to play a given file */
+int module_play_file(const char *filename);
+
+#endif /* _COMMON_H */

--- a/src/common/speak_queue.c
+++ b/src/common/speak_queue.c
@@ -1,8 +1,8 @@
 /*
- * module_utils_speak_queue.c - Speak queue helper for Speech Dispatcher modules
+ * speak_queue.c - Speak queue helper
  *
  * Copyright (C) 2007 Brailcom, o.p.s.
- * Copyright (C) 2019-2020 Samuel Thibault <samuel.thibault@ens-lyon.org>
+ * Copyright (C) 2019-2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -23,11 +23,11 @@
  * Based on ibmtts.c.
  */
 
-#include "module_utils_speak_queue.h"
+#include "speak_queue.h"
+#include "common.h"
+#include "spd_audio.h"
 
 #define DBG_MODNAME "speak_queue"
-
-#include "module_utils.h"
 
 typedef enum {
 	IDLE,

--- a/src/common/speak_queue.h
+++ b/src/common/speak_queue.h
@@ -1,8 +1,8 @@
 /*
- * module_utils_speak_queue.h - Speak queue helper for Speech Dispatcher modules
+ * speak_queue.h - Speak queue helper for Speech Dispatcher modules
  *
  * Copyright (C) 2007 Brailcom, o.p.s.
- * Copyright (C) 2019-2020 Samuel Thibault <samuel.thibault@ens-lyon.org>
+ * Copyright (C) 2019-2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
@@ -128,6 +128,8 @@
 #include <glib.h>
 
 #include "spd_audio_plugin.h"
+
+extern AudioID *module_audio_id;
 
 /* To be called in module_init after synth initialization, to start playback
  * threads.  */

--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -80,7 +80,6 @@ endif
 if ibmtts_support
 modulebin_PROGRAMS += sd_ibmtts
 sd_ibmtts_SOURCES = ibmtts.c $(audio_SOURCES) $(common_SOURCES) \
-	module_utils_speak_queue.c \
 	module_utils_addvoice.c
 sd_ibmtts_LDADD = $(top_builddir)/src/common/libcommon.la \
 	$(audio_dlopen_modules) \
@@ -102,7 +101,7 @@ endif
 
 if espeak_support
 modulebin_PROGRAMS += sd_espeak
-sd_espeak_SOURCES = espeak.c $(audio_SOURCES) $(common_SOURCES) module_utils_speak_queue.c
+sd_espeak_SOURCES = espeak.c $(audio_SOURCES) $(common_SOURCES)
 sd_espeak_LDADD = $(top_builddir)/src/common/libcommon.la \
 	$(audio_dlopen_modules) \
 	-lespeak $(EXTRA_ESPEAK_LIBS) \
@@ -111,7 +110,7 @@ endif
 
 if espeak_ng_support
 modulebin_PROGRAMS += sd_espeak-ng
-sd_espeak_ng_SOURCES = espeak.c $(audio_SOURCES) $(common_SOURCES) module_utils_speak_queue.c
+sd_espeak_ng_SOURCES = espeak.c $(audio_SOURCES) $(common_SOURCES)
 sd_espeak_ng_CFLAGS = -DESPEAK_NG_INCLUDE $(ESPEAK_NG_CFLAGS)
 sd_espeak_ng_LDADD = $(top_builddir)/src/common/libcommon.la \
 	$(audio_dlopen_modules) \
@@ -149,7 +148,7 @@ endif
 
 if baratinoo_support
 modulebin_PROGRAMS += sd_baratinoo
-sd_baratinoo_SOURCES = baratinoo.c baratinoo_compat.h $(audio_SOURCES) $(common_SOURCES) module_utils_speak_queue.c
+sd_baratinoo_SOURCES = baratinoo.c baratinoo_compat.h $(audio_SOURCES) $(common_SOURCES)
 sd_baratinoo_LDADD = $(top_builddir)/src/common/libcommon.la \
 	$(audio_dlopen_modules) -lbaratinoo -lpthread -ldl \
 	$(common_LDADD)
@@ -180,7 +179,7 @@ if kali_shim
 sd_kali_LDADD += -L.
 sd_kali_CPPFLAGS += -I$(srcdir)/kali_shim
 
-noinst_HEADERS = kali_shim/kali/Kali/kali.h module_utils_speak_queue.h
+noinst_HEADERS = kali_shim/kali/Kali/kali.h
 
 EXTRA_sd_kali_DEPENDENCIES = libKali.so libKGlobal.so libKTrans.so libKParle.so libKAnalyse.so
 
@@ -194,7 +193,6 @@ endif
 if voxin_support
 modulebin_PROGRAMS += sd_voxin
 sd_voxin_SOURCES = ibmtts.c $(audio_SOURCES) $(common_SOURCES) \
-	module_utils_speak_queue.c \
 	module_utils_addvoice.c
 sd_voxin_LDADD = $(top_builddir)/src/common/libcommon.la \
 	$(audio_dlopen_modules) \

--- a/src/modules/baratinoo.c
+++ b/src/modules/baratinoo.c
@@ -53,7 +53,7 @@
 
 #include <semaphore.h>
 
-#include "module_utils_speak_queue.h"
+#include "speak_queue.h"
 
 #ifdef BARATINOO_ABI_IS_STABLE_ENOUGH_FOR_ME
 /* See below why this is problematic.  It can however be useful to get the

--- a/src/modules/espeak.c
+++ b/src/modules/espeak.c
@@ -51,7 +51,7 @@
 #include <speechd_types.h>
 #include "module_utils.h"
 
-#include "module_utils_speak_queue.h"
+#include "speak_queue.h"
 
 /* > */
 /* < Basic definitions*/

--- a/src/modules/ibmtts.c
+++ b/src/modules/ibmtts.c
@@ -62,7 +62,7 @@
 #include <speechd_types.h>
 #include "module_utils.h"
 
-#include "module_utils_speak_queue.h"
+#include "speak_queue.h"
 
 typedef enum {
 	MODULE_FATAL_ERROR = -1,

--- a/src/modules/module_utils.c
+++ b/src/modules/module_utils.c
@@ -50,6 +50,36 @@ int module_num_dc_options;
 
 const char *module_name;
 
+void MSG(int level, char *format, ...) {
+	if (level < 4 || Debug) {
+		va_list ap;
+		time_t t;
+		struct timeval tv;
+		char *tstr;
+		t = time(NULL);
+		tstr = g_strdup(ctime(&t));
+		tstr[strlen(tstr)-1] = 0;
+		gettimeofday(&tv,NULL);
+		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec);
+		fprintf(stderr, ": ");
+		va_start(ap, format);
+		vfprintf(stderr, format, ap);
+		va_end(ap);
+		fprintf(stderr, "\n");
+		fflush(stderr);
+		if ((Debug==2) || (Debug==3)) {
+			fprintf(CustomDebugFile," %s [%d]",tstr, (int) tv.tv_usec);
+			fprintf(CustomDebugFile, ": ");
+			va_start(ap, format);
+			vfprintf(CustomDebugFile, format, ap);
+			va_end(ap);
+			fprintf(CustomDebugFile, "\n");
+			fflush(CustomDebugFile);
+		}
+		g_free(tstr);
+	}
+}
+
 #define SET_PARAM_NUM(name, cond) \
 	if(!strcmp(cur_item, #name)){ \
 		char *tptr; \
@@ -550,24 +580,6 @@ void module_sigblockusr(sigset_t * some_signals)
 	if (ret != 0)
 		DBG("Can't block signal set, expect problems when terminating!\n");
 
-}
-
-void set_speaking_thread_parameters()
-{
-	int ret;
-	sigset_t all_signals;
-
-	ret = sigfillset(&all_signals);
-	if (ret == 0) {
-		ret = pthread_sigmask(SIG_BLOCK, &all_signals, NULL);
-		if (ret != 0)
-			DBG("Can't set signal set, expect problems when terminating!\n");
-	} else {
-		DBG("Can't fill signal set, expect problems when terminating!\n");
-	}
-
-	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 }
 
 int module_terminate_thread(pthread_t thread)

--- a/src/modules/module_utils.h
+++ b/src/modules/module_utils.h
@@ -39,8 +39,10 @@
 #include <sys/ipc.h>
 
 #include <speechd_types.h>
+#include "common.h"
 #include "spd_audio.h"
 #include "module_main.h"
+#include "speak_queue.h"
 
 G_BEGIN_DECLS
 
@@ -53,8 +55,6 @@ typedef struct SPDMarks {
 } SPDMarks;
 
 extern int log_level;
-
-extern AudioID *module_audio_id;
 
 extern SPDMsgSettings msg_settings;
 extern SPDMsgSettings msg_settings_old;
@@ -99,37 +99,12 @@ extern const char *module_name;
 	CLEAN_OLD_SETTINGS_TABLE(); \
 } while (0)
 
-#define DBG(arg...) do { \
-	if (Debug){ \
-		time_t t; \
-		struct timeval tv; \
-		char *tstr; \
-		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
-		fprintf(stderr, ": "); \
-		fprintf(stderr, arg); \
-		fprintf(stderr, "\n"); \
-		fflush(stderr); \
-		if ((Debug==2) || (Debug==3)){ \
-			fprintf(CustomDebugFile," %s [%d]",tstr, (int) tv.tv_usec);	\
-			fprintf(CustomDebugFile, ": ");					\
-			fprintf(CustomDebugFile, arg);					\
-			fprintf(CustomDebugFile, "\n");                                   \
-			fflush(CustomDebugFile);			\
-		} \
-		g_free(tstr); \
-	} \
-} while(0)
-
-#define FATAL(msg) do { \
+#define FATAL(msg, ...) do { \
 		fprintf(stderr, "FATAL ERROR in output module [%s:%d]:\n   " msg, \
-		        __FILE__, __LINE__); \
+		        __FILE__, __LINE__, ## __VA_ARGS__); \
 		if (Debug > 1) \
 			fprintf(CustomDebugFile, "FATAL ERROR in output module [%s:%d]:\n   " msg,	\
-			        __FILE__, __LINE__); \
+			        __FILE__, __LINE__, ## __VA_ARGS__); \
 		exit(EXIT_FAILURE); \
 } while (0)
 
@@ -137,7 +112,6 @@ int module_load(void);
 SPDVoice **module_get_voices(void);
 void module_strip_silence(AudioTrack * track);
 int module_tts_output(AudioTrack track, AudioFormat format);
-int module_play_file(const char *filename);
 int module_marks_init(SPDMarks *marks);
 int module_marks_add(SPDMarks *marks, unsigned sample, const char *name);
 int module_tts_output_marks(AudioTrack track, AudioFormat format, SPDMarks *marks);

--- a/src/server/configuration.c
+++ b/src/server/configuration.c
@@ -223,6 +223,8 @@ GLOBAL_FDSET_OPTION_CB_STR(DefaultModule, output_module)
 			&& (val <= 5), "Invalid log (verbosity) level!")
     SPEECHD_OPTION_CB_INT(MaxHistoryMessages, max_history_messages, val >= 0,
 		      "Invalid parameter!")
+    SPEECHD_OPTION_CB_INT(MaxQueueSize, max_queue_size, val >= 0,
+		      "Invalid parameter!")
     SPEECHD_OPTION_CB_INT_M(Timeout, server_timeout, val >= 0, "Invalid timeout value!")
 
     DOTCONF_CB(cb_LanguageDefaultModule)
@@ -440,6 +442,7 @@ configoption_t *load_config_options(int *num_options)
 	ADD_CONFIG_OPTION(DefaultLanguage, ARG_STR);
 	ADD_CONFIG_OPTION(DefaultPriority, ARG_STR);
 	ADD_CONFIG_OPTION(MaxHistoryMessages, ARG_INT);
+	ADD_CONFIG_OPTION(MaxQueueSize, ARG_INT);
 	ADD_CONFIG_OPTION(DefaultPunctuationMode, ARG_STR);
 	ADD_CONFIG_OPTION(SymbolsPreproc, ARG_STR);
 	ADD_CONFIG_OPTION(SymbolsPreprocFile, ARG_STR);
@@ -496,6 +499,7 @@ void load_default_global_set_options()
 	GlobalFDSet.audio_pulse_min_length = 10;
 
 	SpeechdOptions.max_history_messages = 10000;
+	SpeechdOptions.max_queue_size = 20000;
 
 	/* Options which are accessible from command line must be handled
 	   specially to make sure we don't overwrite them */

--- a/src/server/output.c
+++ b/src/server/output.c
@@ -28,6 +28,7 @@
 #include <spd_utils.h>
 #include "output.h"
 #include "parse.h"
+#include "speak_queue.h"
 
 #ifndef HAVE_STRNDUP
 /*
@@ -58,6 +59,7 @@ void output_set_speaking_monitor(TSpeechDMessage * msg, OutputModule * output)
 {
 	/* Set the speaking-monitor so that we know who is speaking */
 	speaking_module = output;
+	module_audio_id = output->audio;
 	speaking_uid = msg->settings.uid;
 	speaking_gid = msg->settings.reparted;
 }
@@ -662,6 +664,40 @@ size_t output_pause()
 	SEND_DATA("PAUSE\n");
 
 	OL_RET(0)
+}
+
+void module_report_index_mark(char *mark)
+{
+	/* TODO */
+}
+void module_report_event_begin(void)
+{
+	/* TODO */
+}
+void module_report_event_end(void)
+{
+	/* TODO */
+}
+void module_report_event_stop(void)
+{
+	/* TODO */
+}
+void module_report_event_pause(void)
+{
+	/* TODO */
+}
+void module_report_icon(const char *icon)
+{
+	/* TODO */
+}
+void module_speak_queue_cancel(void)
+{
+	/* TODO */
+}
+int module_play_file(const char *filename)
+{
+	/* TODO */
+	return -1;
 }
 
 int output_module_is_speaking(OutputModule * output, char **index_mark)

--- a/src/server/speaking.c
+++ b/src/server/speaking.c
@@ -47,6 +47,7 @@ int SPEAKING = 0;
 int poll_count;
 
 OutputModule *speaking_module;
+AudioID *module_audio_id;
 int speaking_uid;
 int speaking_gid;
 

--- a/src/server/speechd.h
+++ b/src/server/speechd.h
@@ -70,6 +70,7 @@ union semun {
 #include <speechd_types.h>
 #include "module.h"
 #include "compare.h"
+#include "common.h"
 
 typedef struct {
 	unsigned int uid;	/* Unique ID of the client */
@@ -169,6 +170,7 @@ extern struct SpeechdOptions {
 	char *debug_destination;
 	char *debug_logfile;
 	int max_history_messages;	/* Maximum of messages in history before they expire */
+	int max_queue_size;
 	int server_timeout;
 	int server_timeout_set;
 } SpeechdOptions;
@@ -229,11 +231,8 @@ TSpeechDSock *speechd_socket_get_by_fd(int fd);
 
 #include "parse.h"
 
-/* Debugging */
-void MSG(int level, char *format, ...);
-void MSG2(int level, char *kind, char *format, ...);
-#define FATAL(msg) do { fatal_error(); MSG(-1,"Fatal error [%s:%d]:"msg, __FILE__, __LINE__); exit(EXIT_FAILURE); } while (0)
-#define DIE(msg) do { MSG(0,"Error [%s:%d]:"msg, __FILE__, __LINE__); exit(EXIT_FAILURE); } while (0)
+#define FATAL(msg, ...) do { fatal_error(); MSG(-1,"Fatal error [%s:%d]:"msg, __FILE__, __LINE__, ## __VA_ARGS__); exit(EXIT_FAILURE); } while (0)
+#define DIE(msg, ...) do { MSG(0,"Error [%s:%d]:"msg, __FILE__, __LINE__, ## __VA_ARGS__); exit(EXIT_FAILURE); } while (0)
 
 extern FILE *logfile;
 extern FILE *custom_logfile;


### PR DESCRIPTION
This will allow to reuse it for server-side audio rendering.
For now the server behavior is not changed, the code is just moved and
corresponding compilation details are fixed.