### PR TITLE
server: Fix flushing audio and pipe on long text

### DIFF
--- a/src/common/speak_queue.h
+++ b/src/common/speak_queue.h
@@ -190,6 +190,8 @@ void module_speak_queue_terminate(void);
 /* To be called last from module_close to release resources.  */
 void module_speak_queue_free(void);
 
+/* Can be called early to quickly discard audio */
+void module_speak_queue_flush(void);
 
 /* To be provided by the module, shall stop the synthesizer, i.e. make
  * it stop calling the module callback, and thus make the module stop calling


### PR DESCRIPTION
We want to unlock all waiting threads as quickly as possible.