### PR TITLE
server: Fix missing wake-up

### DIFF
--- a/src/server/module.c
+++ b/src/server/module.c
@@ -57,6 +57,8 @@ static char *spd_get_path(const char *filename, const char *startdir)
 
 void destroy_module(OutputModule * module)
 {
+	close(module->pipe_speak[0]);
+	close(module->pipe_speak[1]);
 	g_free(module->name);
 	g_free(module->filename);
 	g_free(module->configfilename);
@@ -344,6 +346,8 @@ OutputModule *load_output_module(char *mod_name, char *mod_prog,
 		module->debugfilename = g_strdup(mod_dbgfile);
 	else
 		module->debugfilename = NULL;
+
+	pipe(module->pipe_speak);
 
 	if (!strcmp(mod_name, "testing")) {
 		module->pipe_in[1] = 1;	/* redirect to stdin */

--- a/src/server/module.h
+++ b/src/server/module.h
@@ -34,6 +34,7 @@ typedef struct {
 	char *debugfilename;
 	int pipe_in[2];
 	int pipe_out[2];
+	int pipe_speak[2];
 	FILE *stream_out;
 	int stderr_redirect;
 	pid_t pid;


### PR DESCRIPTION
The main speaking loop needs an fd to know that we have audio events pending
to be read.