### PR TITLE
server: Fix opening server-side audio with daemon mode

### DIFF
--- a/src/server/module.h
+++ b/src/server/module.h
@@ -40,8 +40,8 @@ typedef struct {
 	pid_t pid;
 	int working;
 	AudioID *audio;
-	AudioTrack track;
 } OutputModule;
+#define AUDIOID_TOOPEN ((AudioID*) (-1))
 
 GList *detect_output_modules(const char *modules_dirname, const char *config_dirname);
 OutputModule *load_output_module(const char *mod_name, const char *mod_prog,


### PR DESCRIPTION
We cannot open audio when starting modules, since that is before forking to
daemonize, and fork would drop the pulseaudio mainloop threads, and later on
pulseaudio would try to join etc. them, leading to mayhem.

So delay server-side audio initialization to when we actually need it.