### PR TITLE
module_process: avoid BEGIN events before OK SPEAKING

### DIFF
--- a/src/modules/module_process.c
+++ b/src/modules/module_process.c
@@ -228,11 +228,14 @@ static void cmd_speak(int fd, SPDMessageType msgtype)
 	if (module_speak_sync) {
 		module_speak_sync(text, text_len, msgtype);
 	} else {
+		pthread_mutex_lock(&module_stdout_mutex);
 		ret = module_speak(text, text_len, msgtype);
 		if (ret > 0)
-			module_speak_ok();
+			printf("200 OK SPEAKING\n");
 		else
-			module_speak_error();
+			printf("301 ERROR CANT SPEAK\n");
+		fflush(stdout);
+		pthread_mutex_unlock(&module_stdout_mutex);
 	}
 	free(text);
 }


### PR DESCRIPTION
module_speak may let BEGIN events start appearing before module_speak
returns, so we need to keep the stdout mutex locked to make them wait
for our OK SPEAKING answer.