### PR TITLE
symbols: process symbols.dic before emojis.dic

### DIFF
--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -170,8 +170,8 @@ DefaultVolume 100
 
 SymbolsPreprocFile "gender-neutral.dic"
 SymbolsPreprocFile "font-variants.dic"
-SymbolsPreprocFile "emojis.dic"
 SymbolsPreprocFile "symbols.dic"
+SymbolsPreprocFile "emojis.dic"
 SymbolsPreprocFile "orca.dic"
 SymbolsPreprocFile "orca-chars.dic"
 


### PR DESCRIPTION
emojis.dic contains quite invasive rules, better process the more
fine-grain symbols.dic before this.

Fixes #529