### PR TITLE
symbols: Enable speechd symbols processing by default

### DIFF
--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -160,7 +160,7 @@ DefaultVolume 100
 # rules for spelling spaces. Of course, which rules actually take effect depends
 # on the requested punctuation level.
 
-# SymbolsPreproc "none"
+SymbolsPreproc "char"
 
 # Which preprocessing files should be loaded, and in which order
 #


### PR DESCRIPTION
As announced for 0.10, we planned to enable this so that synthesizers
have a coherent behavior.