### PR TITLE
server: rationalize processing events from output modules

### DIFF
--- a/src/common/speak_queue.h
+++ b/src/common/speak_queue.h
@@ -139,6 +139,7 @@ typedef enum {
 	SPEAK_QUEUE_QET_END,		/* Speech completed. */
 	SPEAK_QUEUE_QET_PAUSE,		/* Speech pause. */
 	SPEAK_QUEUE_QET_STOP,		/* Speech stop. */
+	SPEAK_QUEUE_QET_BROKEN,		/* Speech module is broken. */
 } speak_queue_entry_type;
 
 typedef struct {

--- a/src/server/output.h
+++ b/src/server/output.h
@@ -40,7 +40,6 @@ int output_send_data(const char *cmd, OutputModule * output, int wfr);
 int output_send_settings(TSpeechDMessage * msg, OutputModule * output);
 int output_send_audio_settings(OutputModule * output);
 int output_send_loglevel_setting(OutputModule * output);
-int output_module_is_speaking(OutputModule * output, char **index_mark);
 int waitpid_with_timeout(pid_t pid, int *status_ptr, int options,
 			 size_t timeout);
 int output_close(OutputModule * module);

--- a/src/server/speaking.c
+++ b/src/server/speaking.c
@@ -78,7 +78,7 @@ void *speak(void *data)
 	poll_fds[0].events = POLLIN;
 	poll_fds[0].revents = 0;
 
-	/* module or speak queue fd */
+	/* speak queue fd */
 	poll_fds[1].fd = -1;
 	poll_fds[1].events = POLLIN;
 	poll_fds[1].revents = 0;
@@ -290,10 +290,7 @@ void *speak(void *data)
 		SPEAKING = 1;
 
 		if (speaking_module != NULL) {
-			if (speaking_module->audio)
-				poll_fds[1].fd = speaking_module->pipe_speak[0];
-			else
-				poll_fds[1].fd = speaking_module->pipe_out[0];
+			poll_fds[1].fd = speaking_module->pipe_speak[0];
 			poll_count = 2;
 		}
 


### PR DESCRIPTION
There has always been a race between a client making a request from an
output module (e.g. voice list) while speaking is ongoing. Using select
on the underlying fd of a FILE* is also very doubtful.

We can "simplify" this by just starting a thread that processes the
events. We still have concurrency between client requests and speaking
requests, but this can be managed by dispatching replies and events
accordingly.

Fixes #541