### PR TITLE
Fix htmlpreview doc links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ and the SSIP protocol documentation: doc/ssip.html.
 Read [doc/README](doc/README) for more information.
 
 This documentation is also available online:
-the [speech dispatcher documentation](http://htmlpreview.github.com/?https://github.com/brailcom/speechd/blob/master/doc/speech-dispatcher.html),
-the [spd-say documentation](http://htmlpreview.github.com/?https://github.com/brailcom/speechd/blob/master/doc/spd-say.html),
-and the [SSIP protocol documentation](http://htmlpreview.github.com/?https://github.com/brailcom/speechd/blob/master/doc/ssip.html).
+the [speech dispatcher documentation](http://htmlpreview.github.io/?https://github.com/brailcom/speechd/blob/master/doc/speech-dispatcher.html),
+the [spd-say documentation](http://htmlpreview.github.io/?https://github.com/brailcom/speechd/blob/master/doc/spd-say.html),
+and the [SSIP protocol documentation](http://htmlpreview.github.io/?https://github.com/brailcom/speechd/blob/master/doc/ssip.html).
 
 The key features and the supported TTS engines, output subsystems, client
 interfaces and client applications known to work with Speech Dispatcher are


### PR DESCRIPTION
See https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/