### PR TITLE
ibmtts: Fix load

### DIFF
--- a/src/modules/Makefile.am
+++ b/src/modules/Makefile.am
@@ -88,7 +88,7 @@ sd_ibmtts_LDADD = $(top_builddir)/src/common/libcommon.la \
 
 if ibmtts_shim
 sd_ibmtts_LDADD += -L.
-sd_ibmtts_LDFLAGS = -Wl,-rpath=/opt/IBM/ibmtts/lib
+sd_ibmtts_LDFLAGS = -Wl,--disable-new-dtags -Wl,-rpath=/opt/IBM/ibmtts/lib
 
 EXTRA_sd_ibmtts_DEPENDENCIES = libibmeci.so
 


### PR DESCRIPTION
runpath is not transitive, libibmeci.so would then not find libetidev.
We thus have to stick to rpath, which is transitive.