### PR TITLE
pause: Fix pausing at __spd_ marks only

### DIFF
--- a/doc/speech-dispatcher.html
+++ b/doc/speech-dispatcher.html
@@ -3372,11 +3372,14 @@ separate thread, in which case you need to use
 immediately after starting the production of synthesis. Then
 <code>module_speak_begin()</code> should be called when it actually
 starts emitting audio, and <code>module_speak_end()</code> should be called when it is
-finished emitting audio. In either cases, if <code>module_pause</code> or <code>module_stop</code>
-is getting called, the synthesis should stop as soon as possible, and respectively
-<code>module_speak_pause()</code> or <code>module_speak_stop()</code> be called instead of
-<code>module_speak_end()</code>.  As a first step, <code>module_pause</code> can be made to
-just call <code>module_stop</code>.
+finished emitting audio. In either cases, if <code>module_stop</code>
+is getting called, the synthesis should stop as soon as possible and
+<code>module_speak_stop()</code> be called instead of <code>module_speak_end()</code>.
+Similarly, if <code>module_pause</code> is getting called, the synthesis should stop
+on next mark whose name starts with <code>__spd_</code>, and
+<code>module_speak_pause()</code> be called instead of <code>module_speak_end()</code>.
+As a first step, <code>module_pause</code> can be made to behave just like
+<code>module_stop</code>.
 </p>
 <p>This asynchronous support is examplified in
 <samp>src/modules/skeleton0_espeak-ng-async.c</samp>. It is already quite nice for a lot of
@@ -3734,7 +3737,7 @@ data to soundcard) just after sending an <code>__spd_</code> index
 mark so that Speech Dispatcher knows the position of stop.
 </p>
 <p>The pause can wait for a short time until
-an index mark is reached. However, if it&rsquo;s not possible to determine
+such index mark is reached. However, if it&rsquo;s not possible to determine
 the exact position, this function should have the same effect
 as <code>module_stop</code>.
 </p>

--- a/doc/speech-dispatcher.texi
+++ b/doc/speech-dispatcher.texi
@@ -3034,11 +3034,14 @@ separate thread, in which case you need to use
 immediately after starting the production of synthesis. Then
 @code{module_speak_begin()} should be called when it actually
 starts emitting audio, and @code{module_speak_end()} should be called when it is
-finished emitting audio. In either cases, if @code{module_pause} or @code{module_stop}
-is getting called, the synthesis should stop as soon as possible, and respectively
-@code{module_speak_pause()} or @code{module_speak_stop()} be called instead of
-@code{module_speak_end()}.  As a first step, @code{module_pause} can be made to
-just call @code{module_stop}.
+finished emitting audio. In either cases, if @code{module_stop}
+is getting called, the synthesis should stop as soon as possible and
+@code{module_speak_stop()} be called instead of @code{module_speak_end()}.
+Similarly, if @code{module_pause} is getting called, the synthesis should stop
+on next mark whose name starts with @code{__spd_}, and
+@code{module_speak_pause()} be called instead of @code{module_speak_end()}.
+As a first step, @code{module_pause} can be made to behave just like
+@code{module_stop}.
 
 This asynchronous support is examplified in
 @file{src/modules/skeleton0_espeak-ng-async.c}. It is already quite nice for a lot of
@@ -3386,7 +3389,7 @@ data to soundcard) just after sending an @code{__spd_} index
 mark so that Speech Dispatcher knows the position of stop.
 
 The pause can wait for a short time until
-an index mark is reached. However, if it's not possible to determine
+such index mark is reached. However, if it's not possible to determine
 the exact position, this function should have the same effect
 as @code{module_stop}.
 

--- a/src/modules/baratinoo.c
+++ b/src/modules/baratinoo.c
@@ -514,8 +514,12 @@ void module_speak_sync(const gchar *data, size_t bytes, SPDMessageType msgtype)
 			if (event.type == BARATINOO_MARKER_EVENT) {
 				DBG(DBG_MODNAME "Reached mark '%s' at sample %lu", event.data.marker.name, event.sampleStamp);
 				module_report_index_mark(event.data.marker.name);
-				if (engine->pause_requested)
+				if (engine->pause_requested &&
+					!strncmp(event.data.marker.name,
+						INDEX_MARK_BODY,
+						INDEX_MARK_BODY_LEN)) {
 					engine->pause_index_sent = 1;
+				}
 			}
 		}
 	} while (state == BARATINOO_RUNNING || state == BARATINOO_EVENT);

--- a/src/modules/espeak.c
+++ b/src/modules/espeak.c
@@ -701,8 +701,12 @@ static int synth_callback(short *wav, int numsamples, espeak_EVENT * events)
 		switch (events->type) {
 		case espeakEVENT_MARK:
 			if (EspeakIndexing) {
+				DBG(DBG_MODNAME " Reporting mark %s", events->id.name);
 				module_report_index_mark(events->id.name);
-				if (pause_requested) {
+				if (pause_requested &&
+					!strncmp(events->id.name,
+						INDEX_MARK_BODY,
+						INDEX_MARK_BODY_LEN)) {
 					pause_index_sent = 1;
 					return 1;
 				}

--- a/src/modules/festival.c
+++ b/src/modules/festival.c
@@ -663,9 +663,13 @@ void module_speak_sync(const char *festival_message, size_t bytes, SPDMessageTyp
 						 FestivalReopenSocket);
 
 			if (callback != NULL) {
+				DBG("Reporting mark %s", callback);
 				module_report_index_mark (callback);
 				g_free(callback);
-				if (festival_pause_requested) {
+				if (festival_pause_requested &&
+					!strncmp(callback,
+						INDEX_MARK_BODY,
+						INDEX_MARK_BODY_LEN)) {
 					DBG("Pause requested, pausing.");
 					CLEAN_UP(0, module_report_event_pause);
 				}

--- a/src/modules/ibmtts.c
+++ b/src/modules/ibmtts.c
@@ -1304,7 +1304,7 @@ static void add_mark_to_playback_queue(long markId)
 	}
 	DBG(DBG_MODNAME "reporting index mark |%s|.", mark_name);
 	module_report_index_mark(mark_name);
-	if (pause_requested)
+	if (pause_requested && !strncmp(mark_name, INDEX_MARK_BODY, INDEX_MARK_BODY_LEN))
 		pause_index_sent = TRUE;
 	DBG(DBG_MODNAME "index mark reported.");
 }

--- a/src/server/speak_queue.c
+++ b/src/server/speak_queue.c
@@ -462,7 +462,8 @@ static void *speak_queue_play(void *nothing)
 				if (speak_queue_state == SPEAKING
 				    && speak_queue_pause_state ==
 				    SPEAK_QUEUE_PAUSE_REQUESTED
-				    && speak_queue_stop_or_pause_sleeping) {
+				    && speak_queue_stop_or_pause_sleeping
+				    && g_str_has_prefix(markId, "__spd_")) {
 					DBG(DBG_MODNAME " Pause requested in playback thread.  Stopping.");
 					speak_queue_stop_requested = TRUE;
 					speak_queue_pause_state =


### PR DESCRIPTION
This is needed for speech-dispatcher to be able to restart at the mark.