### PR TITLE
generic: Fix the default encoding to be latin1

### DIFF
--- a/config/modules/epos-generic.conf
+++ b/config/modules/epos-generic.conf
@@ -51,8 +51,8 @@ defaultVoice    "kadlec"
 # you can add it's name (as accepted by iconv) as a
 # third parameter in doublequotes.
 
-GenericLanguage	"cs" "czech"
-GenericLanguage "sk" "slovak"
+GenericLanguage	"cs" "czech" "iso-8859-2"
+GenericLanguage "sk" "slovak" "iso-8859-2"
 
 
 # These parameters set _rate_ and _pitch_ conversion. This is

--- a/doc/speech-dispatcher.texi
+++ b/doc/speech-dispatcher.texi
@@ -916,16 +916,18 @@ GenericExecuteSynth \
 @xref{AddVoice}.
 @end defvr
 
-@defvr {GenericModuleConfiguration} GenericLanguage "iso-code" "string-subst"
+@defvr {GenericModuleConfiguration} GenericLanguage "iso-code" "string-subst" "character-set"
 
 Defines which string @code{string-subst} should be substituted for @code{$LANG}
-given an @code{iso-code} language code.
+given an @code{iso-code} language code. Optionally, the character set in which
+the text will be passed to the module can be specified. If unset, it will
+default to iso-8859-1.
 
 Another example from Epos generic:
 @example
 GenericLanguage "en-US" "english-US"
-GenericLanguage "cs" "czech"
-GenericLanguage "sk" "slovak"
+GenericLanguage "cs" "czech" "iso-8859-2"
+GenericLanguage "sk" "slovak" "iso-8859-2"
 @end example
 @end defvr
 

--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -228,7 +228,7 @@ int module_speak(const gchar * data, size_t bytes, SPDMessageType msgtype)
 	} else {
 		DBG("Warning: Preferred charset not specified, recoding to iso-8859-1");
 		tmp =
-		    (char *)g_convert_with_fallback(data, bytes, "iso-8859-2",
+		    (char *)g_convert_with_fallback(data, bytes, "iso-8859-1",
 						    "UTF-8",
 						    GenericRecodeFallback, NULL,
 						    NULL, NULL);


### PR DESCRIPTION
And document the character set part of GenericLanguage

Fixes #594