### PR TITLE
increase espeak speed to maximum without sonic

### DIFF
--- a/config/modules/espeak-ng.conf
+++ b/config/modules/espeak-ng.conf
@@ -33,7 +33,7 @@ EspeakMinRate 80
 EspeakNormalRate 170
 
 # Maximum rate (100 in speech-dispatcher)
-EspeakMaxRate 390
+EspeakMaxRate 449
 
 # -- Internal parameters --
 

--- a/config/modules/espeak.conf
+++ b/config/modules/espeak.conf
@@ -33,7 +33,7 @@ EspeakMinRate 80
 EspeakNormalRate 170
 
 # Maximum rate (100 in speech-dispatcher)
-EspeakMaxRate 390
+EspeakMaxRate 449
 
 # -- Internal parameters --
 

--- a/src/modules/espeak.c
+++ b/src/modules/espeak.c
@@ -154,7 +154,7 @@ int module_load(void)
 
 	MOD_OPTION_1_INT_REG(EspeakMinRate, 80);
 	MOD_OPTION_1_INT_REG(EspeakNormalRate, 170);
-	MOD_OPTION_1_INT_REG(EspeakMaxRate, 390);
+	MOD_OPTION_1_INT_REG(EspeakMaxRate, 449);
 	MOD_OPTION_1_STR_REG(EspeakPunctuationList, "@/+-_");
 	MOD_OPTION_1_INT_REG(EspeakCapitalPitchRise, 800);
 	MOD_OPTION_1_INT_REG(EspeakIndexing, 1);


### PR DESCRIPTION
I'm not sure if I need to change the espeak config I only tested espeak-ng

maybe we should increase the minimum and average speed too.