### PR TITLE
modules: Move Debug configuration option to beginning of file

### DIFF
--- a/config/modules/baratinoo.conf
+++ b/config/modules/baratinoo.conf
@@ -1,3 +1,7 @@
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+
+# Debug 0
 
 # Path to the Baratinoo configuration file.  Defaults to $BARATINOO_CONFIG_PATH
 # or XDG_CONFIG_HOME/baratinoo.cfg
@@ -31,11 +35,6 @@ BaratinooMaxRate	150
 # between 10 and 100.
 #BaratinooResponsiveness -1
 
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-
-# Debug 0
-
 # DebugFile specifies the file where the debugging information
 # should be stored (note that the log is overwritten each time
 # the module starts)
@@ -43,7 +42,7 @@ BaratinooMaxRate	150
 
 
 # Copyright (C) 2017 Colomban Wendling <cwendling@hypra.fr>
-# Copyright (C) 2018 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2018, 2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software

--- a/config/modules/cicero.conf
+++ b/config/modules/cicero.conf
@@ -1,3 +1,7 @@
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+
+# Debug 0
 
 # -- CICERO EXECUTABLE AND LOG --
 
@@ -23,12 +27,6 @@
 # documentation
 
 # -- DEBUGING AND LOGING --
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-
-#Debug 0
-
 
 # Copyright (C) 2006 Olivier BERT <obert01@mistigri.org>
 # Copyright (C) 2006 Brailcom, o.p.s

--- a/config/modules/dtk-generic.conf
+++ b/config/modules/dtk-generic.conf
@@ -8,6 +8,11 @@
 # Please note that DECTalk software is currently *not* Free Software.
 # You might want to look at Festival instead.
 
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+
+# Debug 0
+
 # GenericExecuteSynth is the shell command that should be
 # executed in order to say some message. This command must
 # stop saying the message on SIGKILL, otherwise it's useless.
@@ -86,11 +91,6 @@ GenericPitchAdd	225
 
 GenericRateMultiply 262
 GenericPitchMultiply 175 
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-
-# Debug 0
 
 
 

--- a/config/modules/epos-generic.conf
+++ b/config/modules/epos-generic.conf
@@ -9,6 +9,10 @@
 # system (it might be "say"), or (better) create a link epos-say
 # somewhere in your path to the epos's say client.
 
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+# Debug 0
+
 
 # GenericExecuteSynth is the shell command that should be
 # executed in order to say some message. This command must
@@ -82,10 +86,6 @@ GenericPitchMultiply 100
 #GenericRateForceInteger 0
 #GenericPitchForceInteger 0
 #GenericVolumeForceInteger 0
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-# Debug 0
 
 
 # Copyright (C) 2003-2008 Brailcom, o.p.s

--- a/config/modules/espeak-mbrola-generic.conf
+++ b/config/modules/espeak-mbrola-generic.conf
@@ -3,7 +3,11 @@
 # this plugin, all the specifics are handled in this configuration
 # and we call a simple command line client to perform the actual
 # synthesis. Use this config file with the sd_generic output module.
-#
+
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+Debug 0
+
 # IMPORTANT: The audio output method relies on an audio playback
 # utility (play, aplay, paplay for OSS, ALSA or Pulse)
 # being installed. If this is not the case, consider installing it
@@ -208,10 +212,6 @@ GenericPitchForceInteger    1
 GenericVolumeForceInteger   0
 
 # Note that SSIP rates < -50 are spoken at -50.
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-Debug 0
 
 
 # Copyright (C) 2008-2010 Brailcom, o.p.s

--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -3,7 +3,11 @@
 # this plugin, all the specifics are handled in this configuration
 # and we call a simple command line client to perform the actual
 # synthesis. Use this config file with the sd_generic output module.
-#
+
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+Debug 0
+
 # IMPORTANT: The audio output method relies on an audio playback
 # utility (play, aplay, paplay for OSS, ALSA or Pulse)
 # being installed. If this is not the case, consider installing it
@@ -262,10 +266,6 @@ GenericPitchForceInteger    1
 GenericVolumeForceInteger   0
 
 # Note that SSIP rates < -50 are spoken at -50.
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-Debug 0
 
 
 # Copyright (C) 2008-2010 Brailcom, o.p.s

--- a/config/modules/espeak-ng.conf
+++ b/config/modules/espeak-ng.conf
@@ -1,3 +1,6 @@
+# Debugging
+Debug 0
+
 
 # -- SOUND ICONS --
 
@@ -45,9 +48,6 @@ EspeakAudioQueueMaxSize 441000
 
 # Whether to enable speech indexing
 EspeakIndexing 1
-
-# Debugging
-Debug 0
 
 
 # Copyright (C) 2007 Lukas Loehrer <listaddr1@gmx.net>

--- a/config/modules/espeak.conf
+++ b/config/modules/espeak.conf
@@ -1,3 +1,6 @@
+# Debugging
+Debug 0
+
 
 # -- SOUND ICONS --
 
@@ -45,9 +48,6 @@ EspeakAudioQueueMaxSize 441000
 
 # Whether to enable speech indexing
 EspeakIndexing 1
-
-# Debugging
-Debug 0
 
 
 # Copyright (C) 2007 Lukas Loehrer <listaddr1@gmx.net>

--- a/config/modules/festival.conf
+++ b/config/modules/festival.conf
@@ -1,3 +1,9 @@
+# -- DEBUGING --
+
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+Debug 0
+
 
 # -- FESTIVAL SERVER SETTINGS --
 
@@ -62,12 +68,6 @@
 
 # FestivalReopenSocket 0
 
-
-# -- DEBUGING --
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-Debug 0
 
 # If FestivalDebugSaveOutput is set to 1, it writes the produced sound tracks
 # to /tmp/debug-festival-*.snd before it says them. You can later browse them

--- a/config/modules/flite.conf
+++ b/config/modules/flite.conf
@@ -1,12 +1,12 @@
-
-# See Festival commands comments for information
-FliteMaxChunkLength    500
-FliteDelimiters        ".?!;"
-
 # Debug turns debugging on or off
 # See speechd.conf for information where debugging information is stored
 
 # Debug 0
+
+
+# See Festival commands comments for information
+FliteMaxChunkLength    500
+FliteDelimiters        ".?!;"
 
 
 # DebugFile specifies the file where the debugging information

--- a/config/modules/ibmtts.conf
+++ b/config/modules/ibmtts.conf
@@ -1,3 +1,18 @@
+# -- DEBUG --
+
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored.
+
+# TODO: Change this to 0 and comment out for final release.
+
+Debug 0
+
+# DebugFile specifies the file where the debugging information
+# should be stored (note that the log is overwritten each time
+# the module starts)
+
+# DebugFile "/tmp/debug-ibmtts"
+
 
 # The number of samples returned by IBM TTS.
 #IbmttsAudioChunkSize 20000
@@ -100,21 +115,6 @@ IbmttsUseAbbreviation 1
 # matching file is found, the name of the sound icon will be spoken.
 
 #IbmttsSoundIconFolder "/usr/share/sounds/sound-icons/"
-
-# -- DEBUG --
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored.
-
-# TODO: Change this to 0 and comment out for final release.
-
-Debug 0
-
-# DebugFile specifies the file where the debugging information
-# should be stored (note that the log is overwritten each time
-# the module starts)
-
-# DebugFile "/tmp/debug-ibmtts"
 
 # -- VOICE PARAMETERS --
 

--- a/config/modules/ivona.conf
+++ b/config/modules/ivona.conf
@@ -1,3 +1,6 @@
+# Debug level - see Festival module configuration
+Debug 0
+
 
 
 # Host and port - default values 
@@ -6,9 +9,6 @@
 
 #Sample Frequency
 #IvonaSampleFreq 16000
-
-# Debug level - see Festival module configuration
-Debug 0
 
 
 # DebugFile specifies the file where the debugging information

--- a/config/modules/kali.conf
+++ b/config/modules/kali.conf
@@ -1,3 +1,8 @@
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+
+# Debug 0
+
 # -- Kali parameters --
 
 KaliMaxChunkLength    4999
@@ -30,11 +35,6 @@ KaliNormalPitch 6
 # expand abbreviations in the engine.
 KaliExpandAbbreviations 1
 
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-
-# Debug 0
 
 
 # Copyright (C) 2018 Raphaël POITEVIN <rpoitevin@hypra.fr>

--- a/config/modules/llia_phon-generic.conf
+++ b/config/modules/llia_phon-generic.conf
@@ -9,6 +9,14 @@
 # work to be really useful. We plan to finish it as soon as llia_phon
 # is fixed in it's CVS.
 
+# Debug turns debugging on or off
+# Debug 0
+
+# DebugFile specifies the file where the debugging information
+# should be stored (note that the log is overwritten each time
+# the module starts)
+# DebugFile "/tmp/debug-llia-phon-generic"
+
 # GenericExecuteSynth is the shell command that should be
 # executed in order to say some message. This command must
 # stop saying the message on SIGKILL, otherwise it's useless.
@@ -67,14 +75,6 @@ GenericPitchMultiply 100
 #GenericRateForceInteger 0
 #GenericPitchForceInteger 0
 #GenericVolumeForceInteger 0
-
-# Debug turns debugging on or off
-# Debug 0
-
-# DebugFile specifies the file where the debugging information
-# should be stored (note that the log is overwritten each time
-# the module starts)
-# DebugFile "/tmp/debug-llia-phon-generic"
 
 
 # Copyright (C) 2004-2008 Brailcom, o.p.s

--- a/config/modules/mary-generic.conf
+++ b/config/modules/mary-generic.conf
@@ -3,7 +3,11 @@
 # this plugin, all the specifics are handled in this configuration
 # and we call a simple command line client to perform the actual
 # synthesis. Use this config file with the sd_generic output module.
-#
+
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+Debug 0
+
 # IMPORTANT: The audio output method relies on an audio playback
 # utility (play, aplay, paplay for OSS, ALSA or Pulse)
 # being installed. If this is not the case, consider installing it
@@ -139,10 +143,6 @@ GenericPitchForceInteger    1
 GenericVolumeForceInteger   0
 
 # Note that SSIP rates < -50 are spoken at -50.
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-Debug 0
 
 
 # Copyright (C) 2018 Florian Steinhardt <no.known.email@example.com>

--- a/config/modules/pico.conf
+++ b/config/modules/pico.conf
@@ -1,6 +1,6 @@
-#PicoLingwarePath "/usr/share/pico/lang/"
-
 #Debug 1
+
+#PicoLingwarePath "/usr/share/pico/lang/"
 
 
 # Copyright (C) 2010 Andrei Kholodnyi <andrei.kholodnyi@gmail.com>

--- a/config/modules/swift-generic.conf
+++ b/config/modules/swift-generic.conf
@@ -5,7 +5,11 @@
 # synthesis. Note that this is not an optimal solution, but
 # it's reported to work.
 #Use this config file with the sd_generic output module.
-#
+
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored
+# Debug 0
+
 # IMPORTANT: The audio output method relies on an audio playback
 # utility (play, aplay, paplay for OSS, ALSA or Pulse)
 # being installed. If this is not the case, consider installing it
@@ -69,10 +73,6 @@ GenericPitchAdd 1
 
 GenericRateMultiply 262
 GenericPitchMultiply 1
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored
-# Debug 0
 
 
 # Copyright (C) 2008 Brailcom, o.p.s

--- a/config/modules/voxin.conf
+++ b/config/modules/voxin.conf
@@ -1,3 +1,18 @@
+# -- DEBUG --
+
+# Debug turns debugging on or off
+# See speechd.conf for information where debugging information is stored.
+
+# TODO: Change this to 0 and comment out for final release.
+
+Debug 0
+
+# DebugFile specifies the file where the debugging information
+# should be stored (note that the log is overwritten each time
+# the module starts)
+
+# DebugFile "/tmp/debug-ibmtts"
+
 
 # The number of samples returned by IBM TTS.
 #IbmttsAudioChunkSize 20000
@@ -90,21 +105,6 @@ IbmttsUseAbbreviation 1
 # matching file is found, the name of the sound icon will be spoken.
 
 #IbmttsSoundIconFolder "/usr/share/sounds/sound-icons/"
-
-# -- DEBUG --
-
-# Debug turns debugging on or off
-# See speechd.conf for information where debugging information is stored.
-
-# TODO: Change this to 0 and comment out for final release.
-
-Debug 0
-
-# DebugFile specifies the file where the debugging information
-# should be stored (note that the log is overwritten each time
-# the module starts)
-
-# DebugFile "/tmp/debug-ibmtts"
 
 # -- VOICE PARAMETERS --
 


### PR DESCRIPTION
This allows to get debugging prints from option parsing.