### PR TITLE
generic: Fix setting the language without any specific voice type

### DIFF
--- a/src/modules/module_utils_addvoice.c
+++ b/src/modules/module_utils_addvoice.c
@@ -228,6 +228,7 @@ char *module_getvoice(const char *language, SPDVoiceType voice)
 	}
 
 	switch (voice) {
+	case -1:
 	case SPD_MALE1:
 		ret = voices->male1;
 		break;


### PR DESCRIPTION
In that case, fallback to the male1 default.