### PR TITLE
addvoice: Avoid printing errors on stdout

### DIFF
--- a/src/modules/module_utils_addvoice.c
+++ b/src/modules/module_utils_addvoice.c
@@ -254,7 +254,7 @@ char *module_getvoice(const char *language, SPDVoiceType voice)
 		ret = voices->child_female;
 		break;
 	default:
-		printf("Unknown voice");
+		fprintf(stderr, "Unknown voice %d", voice);
 		return NULL;
 	}
 


### PR DESCRIPTION
otherwise it'd mix with the protocol with the server, making the module
unusable afterwards.