### PR TITLE
modules: Do not stop loading only because the config file is missing

### DIFF
--- a/src/modules/module_config.c
+++ b/src/modules/module_config.c
@@ -54,8 +54,8 @@ int module_config(const char *configfilename) {
 			   CASE_INSENSITIVE);
 
 	if (!configfile) {
-		DBG("Can't read specified config file!\n");
-		return -1;
+		DBG("Can't read specified config file! Using defaults...\n");
+		return 0;
 	}
 
 	if (dotconf_command_loop(configfile) == 0) {


### PR DESCRIPTION
Better speak with default parameters than not speak at all.  That's very
notably very important for the dummy module which doesn't have a config
file, and must work at all times anyway.