### PR TITLE
Do not set the espeak-ng module by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,7 @@ Version 0.11
 * Add script to run speechd from the build tree.
 * Update CLDR to version 39, symbols from NVDA and orca.
 * Add Esperanto translation.
+* Sort modules by quality, let the best quality module be the default.
 
 Version 0.10.2
 * generic: Add support for sound icons

--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -289,7 +289,7 @@ SymbolsPreprocFile "orca-chars.dic"
 # The DefaultModule selects which output module is the default.  You
 # must use one of the names of the modules loaded with AddModule.
 
-DefaultModule espeak-ng
+#DefaultModule espeak-ng
 
 # The LanguageDefaultModule selects which output modules are prefered
 # for specified languages.


### PR DESCRIPTION
Now that we properly detect the list of actually working modules, and sorted
by quality, we can just automatically default to the first (thus best)
available module.