### PR TITLE
Revert module_espeak to taking a const pointer

### DIFF
--- a/src/modules/cicero.c
+++ b/src/modules/cicero.c
@@ -241,7 +241,7 @@ SPDVoice **module_list_voices(void)
 	return NULL;
 }
 
-int module_speak(const gchar * data, size_t bytes, SPDMessageType msgtype)
+int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 {
 	DBG("Module speak\n");
 

--- a/src/modules/dummy.c
+++ b/src/modules/dummy.c
@@ -97,7 +97,7 @@ SPDVoice **module_list_voices(void)
 	return NULL;
 }
 
-int module_speak(const gchar * data, size_t bytes, SPDMessageType msgtype)
+int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 {
 
 	DBG("speak()\n");

--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -198,7 +198,7 @@ SPDVoice **module_list_voices(void)
 	return module_list_registered_voices();
 }
 
-int module_speak(const gchar * data, size_t bytes, SPDMessageType msgtype)
+int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 {
 	char *tmp;
 

--- a/src/modules/module_main.h
+++ b/src/modules/module_main.h
@@ -54,7 +54,7 @@ int module_init(char **msg);
 SPDVoice **module_list_voices(void);
 
 /* Asynchronous Speak */
-int module_speak(const char *data, size_t bytes, SPDMessageType msgtype);
+int module_speak(char *data, size_t bytes, SPDMessageType msgtype);
 
 /* Synchronous Speak */
 void module_speak_sync(const char *data, size_t bytes, SPDMessageType msgtype);

--- a/src/modules/skeleton0.c
+++ b/src/modules/skeleton0.c
@@ -205,7 +205,7 @@ void module_speak_sync(const char *data, size_t bytes, SPDMessageType msgtype)
 #else
 /* Asynchronous version, when the synthesis implements asynchronous
  * processing in another thread. */
-int module_speak(const char *data, size_t bytes, SPDMessageType msgtype)
+int module_speak(char *data, size_t bytes, SPDMessageType msgtype)
 {
 	/* TODO: Speak the provided data asynchronously in another thread */
 	fprintf(stderr, "speaking '%s'\n", data);

--- a/src/modules/skeleton0_espeak-ng-async-server.c
+++ b/src/modules/skeleton0_espeak-ng-async-server.c
@@ -216,7 +216,7 @@ int module_loop(void)
 static int began;
 /* Asynchronous version, when the synthesis implements asynchronous
  * processing in another thread. */
-int module_speak(const char *data, size_t bytes, SPDMessageType msgtype)
+int module_speak(char *data, size_t bytes, SPDMessageType msgtype)
 {
 	/* Speak the provided data asynchronously in another thread */
 	fprintf(stderr, "speaking '%s'\n", data);

--- a/src/modules/skeleton0_espeak-ng-async.c
+++ b/src/modules/skeleton0_espeak-ng-async.c
@@ -233,7 +233,7 @@ int module_loop(void)
 static int began;
 /* Asynchronous version, when the synthesis implements asynchronous
  * processing in another thread. */
-int module_speak(const char *data, size_t bytes, SPDMessageType msgtype)
+int module_speak(char *data, size_t bytes, SPDMessageType msgtype)
 {
 	/* Speak the provided data asynchronously in another thread */
 	fprintf(stderr, "speaking '%s'\n", data);

--- a/src/modules/skeleton_config.c
+++ b/src/modules/skeleton_config.c
@@ -126,7 +126,7 @@ void module_speak_sync(const char *data, size_t bytes, SPDMessageType msgtype)
 #else
 /* Asynchronous version, when the synthesis implements asynchronous
  * processing in another thread. */
-int module_speak(const char *data, size_t bytes, SPDMessageType msgtype)
+int module_speak(char *data, size_t bytes, SPDMessageType msgtype)
 {
 	/* Update synth parameters according to message parameters */
 	UPDATE_PARAMETER(rate, skeleton_set_rate);


### PR DESCRIPTION
This is needeed to keep API compatibility with previous C++ modules,
which would define a function without the const qualifier, thus not
matching the C prototype, and thus getting mangled, and thus the
module_speak weak ref would fail.