### PR TITLE
spd-conf: Improve config copying

### DIFF
--- a/src/api/python/speechd_config/config.py
+++ b/src/api/python/speechd_config/config.py
@@ -602,7 +602,17 @@ Do you want to keep it?"""), False)
                     return
         # Copy the original intact configuration files
         # creating a conf/ subdirectory
-        shutil.copytree(buildconfig.SPD_CONF_ORIG_PATH, self.test.user_conf_dir())
+        config_root = self.test.user_conf_dir()
+        shutil.copytree(buildconfig.SPD_CONF_ORIG_PATH, config_root)
+        # Ensure the files are writeable when copying from immutable directory.
+        umask = os.umask(0)
+        os.umask(umask)
+        os.chmod(self.test.user_conf_dir() , 0o755 & ~umask)
+        for root, dirs, files in os.walk(self.test.user_conf_dir()):
+            for d in dirs:
+                os.chmod(os.path.join(root, d), 0o755 & ~umask)
+            for f in files:
+                os.chmod(os.path.join(root, f), 0o644 & ~umask)
 
         report(_("User configuration created in %s" % self.test.user_conf_dir()))
 

--- a/src/api/python/speechd_config/config.py
+++ b/src/api/python/speechd_config/config.py
@@ -677,8 +677,10 @@ Do you want to keep it?"""), False)
 This is usually not necessary, most applications will start Speech Dispatcher automatically."""),
                 False)
             if setup_autostart:
-                os.system("""cp %s ~/.config/autostart/""" % os.path.join(buildconfig.SPD_DESKTOP_CONF_PATH,
-                                                                          "speechd.desktop"))
+                shutil.copy(
+                    os.path.join(buildconfig.SPD_DESKTOP_CONF_PATH, "speechd.desktop"),
+                    os.path.join(BaseDirectory.xdg_config_home, "autostart/")
+                )
 
                 report(_("""
 Configuration written to %s


### PR DESCRIPTION
- spd-conf: Do not copy config permission attributes
- spd-conf: Respect XDG basedir spec for autostart
