### PR TITLE
Fix make distcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,6 @@ $(top_srcdir)/.version:
 dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball-version
 	echo $(VERSION) > $(distdir)/.version
-	rm $(distdir)/po/speech-dispatcher.pot
 
 -include $(top_srcdir)/git.mk
 

--- a/build.sh
+++ b/build.sh
@@ -21,12 +21,10 @@
 # Just call autoreconf -i.  This script should really go away, but we're
 # keeping it, because people are used to it.
 rm -f ABOUT-NLS
-rm -f po/remove-potcdate.sin
 autoreconf -fi
 
 # See https://savannah.gnu.org/bugs/index.php?54809
 rm -f \
-./po/remove-potcdate.sin \
 ./po/quot.sed \
 ./po/boldquot.sed \
 ./po/en@quot.header \
@@ -36,4 +34,3 @@ rm -f \
 ./ABOUT-NLS
 
 touch ABOUT-NLS
-touch po/remove-potcdate.sin

--- a/po/speech-dispatcher.pot
+++ b/po/speech-dispatcher.pot
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: speech-dispatcher 0.11.1\n"
+"Project-Id-Version: speech-dispatcher 0.11.1.99\n"
 "Report-Msgid-Bugs-To: speechd-discuss@nongnu.org\n"
 "POT-Creation-Date: 2022-01-09 01:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Removing po/speech-dispatcher.pot means that further on it'll try to
recreate it but source code is supposed to be non-writable.