### PR TITLE
Fix module-bindir help text

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -488,7 +488,7 @@ AC_SUBST([localedatadir])
 
 # Path for module binaries:
 AC_ARG_WITH([module-bindir],
-	AS_HELP_STRING([--with-module-bindir],[Directory where to install speech-dispatcher modules (defaults to ${libdir}/speech-dispatcher-modules)]),
+	AS_HELP_STRING([--with-module-bindir],[Directory where to install speech-dispatcher modules (defaults to ${libexecdir}/speech-dispatcher-modules)]),
 	[modulebindir=$withval], [modulebindir='${libexecdir}/speech-dispatcher-modules'])
 AC_SUBST([modulebindir])
 


### PR DESCRIPTION
Update the module-bindir help text in configure.ac to reflect that the
default module-bindir location is now in {libexecdir} rather than
{libdir} (from commit 7e2b8409f948d5f9d3f0c1e8e859052b6c3f3872).