### PR TITLE
FIx typos in `config/`

### DIFF
--- a/config/modules/cicero.conf
+++ b/config/modules/cicero.conf
@@ -26,7 +26,7 @@
 # be influenced from this place. Please see Cicero
 # documentation
 
-# -- DEBUGING AND LOGING --
+# -- DEBUGGING AND LOGGING --
 
 # Copyright (C) 2006 Olivier BERT <obert01@mistigri.org>
 # Copyright (C) 2006 Brailcom, o.p.s

--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -105,8 +105,8 @@ VoiceFileDependency "/usr/share/espeak-ng-data/voices/mb/mb-$VOICE"
 # rationale to not include them by default. You still can ship or use
 # the commented voices if you uncomment the corresponding line.
   
-# As of Friday 12 October 2018 theses mbrola voices not yet supported 
-# by espeak-ng's phonemes translation to mbrola in git are:
+# As of Friday 12 October 2018 these mbrola voices aren't yet 
+# supported by espeak-ng's phonemes translation to mbrola in git are:
 # bz1: Breton Female (25.0Mb)    Jean Pierre Messager
 # hb1: Hebrew Male (3.4Mb)    Yoram Meron
 # hb2: Hebrew Female (5.6Mb)    Esther Raizen

--- a/config/modules/festival.conf
+++ b/config/modules/festival.conf
@@ -1,4 +1,4 @@
-# -- DEBUGING --
+# -- DEBUGGING --
 
 # Debug turns debugging on or off
 # See speechd.conf for information where debugging information is stored
@@ -28,7 +28,7 @@ Debug 0
 
 # FestivalCacheOn 1
 
-# How large should the memmory assigned to output module for
+# How large should the memory assigned to output module for
 # cache should be. Festival will never overcome this limit.
 # If there are more messages to save, the ones that are least
 # accessed will be removed from the cache. So if you set this
@@ -60,7 +60,7 @@ Debug 0
 # connection to Festival each time the currently synthesized wavefile
 # is no longer needed to finish and new text is waiting. This may improve
 # Festival responsivity on slower machines, but might cause a more network
-# trafic. Currently, the option is set to 0 by default, because there
+# traffic. Currently, the option is set to 0 by default, because there
 # is a network problem in Festival socket communication layer that introduces
 # unnecessary delays that affect the performance heavily in this mode.
 # Unless your Festival is patched against this bug, switching this on

--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -9,7 +9,7 @@
 #
 # unix_socket -- communication over Unix sockets represented by a file in the
 # filesystem (see SocketPath below). This method works only locally, but is
-# prefered for standard session setup, where every user runs his own instance of Speech
+# preferred for standard session setup, where every user runs his own instance of Speech
 # Dispatcher to get voice feedback on his own computer.
 #
 # inet_socket -- alternatively, you can start Speech Dispatcher on
@@ -291,7 +291,7 @@ SymbolsPreprocFile "orca-chars.dic"
 
 #DefaultModule espeak-ng
 
-# The LanguageDefaultModule selects which output modules are prefered
+# The LanguageDefaultModule selects which output modules are preferred
 # for specified languages.
 
 #LanguageDefaultModule "en"  "espeak"


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po`