### PR TITLE
spd_wchar: Initialize buffer before using

### DIFF
--- a/src/api/c/libspeechd.c
+++ b/src/api/c/libspeechd.c
@@ -879,10 +879,10 @@ spd_wchar(SPDConnection * connection, SPDPriority priority, wchar_t wcharacter)
 
 	pthread_mutex_lock(&connection->ssip_mutex);
 
-	memset(character, 0, sizeof(character));
 	ret = wcrtomb(character, wcharacter, NULL);
 	if (ret <= 0)
 		RET(-1);
+	character[ret] = '\0';
 
 	ret = spd_set_priority(connection, priority);
 	if (ret)

--- a/src/api/c/libspeechd.c
+++ b/src/api/c/libspeechd.c
@@ -879,6 +879,7 @@ spd_wchar(SPDConnection * connection, SPDPriority priority, wchar_t wcharacter)
 
 	pthread_mutex_lock(&connection->ssip_mutex);
 
+	memset(character, 0, sizeof(character));
 	ret = wcrtomb(character, wcharacter, NULL);
 	if (ret <= 0)
 		RET(-1);


### PR DESCRIPTION
Wcrtomb doesn't write a null byte after processing the character, but the
buffer is later assumed to be terminated.