### PR TITLE
drop ltdl dependency in favor of native dlopen(3) interfaces

### DIFF
--- a/src/modules/module_config.c
+++ b/src/modules/module_config.c
@@ -20,7 +20,9 @@
  */
 
 #include <dotconf.h>
+#ifndef USE_DLOPEN
 #include <ltdl.h>
+#endif
 
 #include "module_main.h"
 #include "module_utils.h"
@@ -28,8 +30,10 @@
 int module_config(const char *configfilename) {
 	int ret;
 
+#ifndef USE_DLOPEN
 	/* Initialize ltdl's list of preloaded audio backends. */
 	LTDL_SET_PRELOADED_SYMBOLS();
+#endif
 
 	module_num_dc_options = 0;
 	module_audio_id = 0;


### PR DESCRIPTION
there's no platform(s) where ltdl is necessary anymore that anyone would want to build and use speechd on, and this fixes building speechd w/ slibtool. #611 

however I don't know how to properly test the module loading to make sure it's correct so please don't merge before it's verified to actually work... :-)