### PR TITLE
Avoid speech-dispatcher service shutting down

### DIFF
--- a/speech-dispatcherd.service.in
+++ b/speech-dispatcherd.service.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2018, 2022 Samuel Thibault <samuel.thibault@ens-lyon.org>
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -18,7 +18,7 @@ Description=Speech-Dispatcher, common interface to speech synthesizers
 
 [Service]
 Type=forking
-ExecStart=@bindir@/speech-dispatcher -d
+ExecStart=@bindir@/speech-dispatcher -d -t 0
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
When speech-dispatcher is started as a service, we do not want to see it
shut down automatically.