### PR TITLE
Only install user units if libsystemd is available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS=--without-systemdsystemunitdir --without-systemduse
 
 nodist_systemdsystemunit_DATA = \
 	speech-dispatcherd.service
-if HAVE_SYSTEMD
+if USE_LIBSYSTEMD
 nodist_systemduserunit_DATA = \
 	speech-dispatcher.service speech-dispatcher.socket
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -118,11 +118,7 @@ PKG_CHECK_MODULES([SNDFILE], [sndfile >= 1.0.2])
 AC_SUBST([SNDFILE_CFLAGS])
 AC_SUBST([SNDFILE_LIBS])
 
-PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd], [have_systemd="yes"], [have_systemd="no"])
-if test x$have_systemd = xyes; then
-    AC_DEFINE([HAVE_SYSTEMD], [1], [Define to 1 if you have the systemd library])
-fi
-AM_CONDITIONAL(HAVE_SYSTEMD, [test x$have_systemd = xyes])
+PKG_CHECK_MODULES([LIBSYSTEMD], [libsystemd], [have_libsystemd=yes], [:])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h langinfo.h limits.h netdb.h])
@@ -551,10 +547,12 @@ AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_sy
 AC_ARG_WITH([systemduserunitdir],
         AS_HELP_STRING([--with-systemduserunitdir=DIR], [Directory for systemd user service files]),
         [], [with_systemduserunitdir=$($PKG_CONFIG --variable=systemduserunitdir systemd)])
-if test "x$with_systemduserunitdir" != xno; then
+if test -n "$have_libsystemd" -a -n "$with_systemduserunitdir" -a "x$with_systemduserunitdir" != xno ; then
+        use_libsystemd=yes
         AC_SUBST([systemduserunitdir], [$with_systemduserunitdir])
+        AC_DEFINE([USE_LIBSYSTEMD], [1], [Used for activation via socket])
 fi
-AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemduserunitdir" -a "x$with_systemduserunitdir" != xno ])
+AM_CONDITIONAL([USE_LIBSYSTEMD], [test "x$use_libsystemd" = "xyes"])
 
 AM_CONDITIONAL(BUILD_HTML_DOC, [test "$EMAIL" = samuel.thibault@ens-lyon.org])
 

--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -29,7 +29,7 @@
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/un.h>
-#ifdef HAVE_SYSTEMD
+#ifdef USE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
 
@@ -1286,7 +1286,7 @@ int main(int argc, char *argv[])
 		g_free(spawn_socket_path);
 	}
 
-#ifdef HAVE_SYSTEMD
+#ifdef USE_LIBSYSTEMD
 	if (sd_listen_fds(0) >= 1) {
 		/* Daemon launched via Systemd socket activation */
 		server_socket = SD_LISTEN_FDS_START;


### PR DESCRIPTION
This is a follow up to merge request #763.

If Libsystemd were not available to the system, the previous implementation would nonetheless install both the socket and the dispatcher.service, which, although not a bug, wouldn't be used.

I'm also renaming HAVE_SYSTEMD to USE_SYSTEMDLIB because 

1. that's the module being checked
2. even if available, the user could choose not to use it by passing `--without-systemduserunitdir`.