### PR TITLE
Update updating symbols instructions

### DIFF
--- a/locale/.gitignore
+++ b/locale/.gitignore
@@ -19,5 +19,4 @@
 /Makefile.in
 /TAGS
 /so_locations
-/symbolsrc
 /tags

--- a/locale/Makefile.am
+++ b/locale/Makefile.am
@@ -380,4 +380,3 @@ uninstall-hook:
 	done
 
 -include $(top_srcdir)/git.mk
-GITIGNOREFILES = symbolsrc

--- a/locale/README.md
+++ b/locale/README.md
@@ -2,13 +2,11 @@
 
 * Get gettext version 0.20 or later
 * Install the latest version of orca master by hand
-* Create a directory named symbolsrc in the locale directory of Speech-Dispatcher source tree.
 * Download NVDA sources using this link: (https://github.com/nvaccess/nvda/archive/beta.zip)
-* Extract the archive in the newly created directory which will create a nvda-beta folder
-* Download the latest unicode CLDR release from this webpage: (http://cldr.unicode.org/index/downloads)
-* In the table, chose the latest release which has a date specified and click on the "data" link
-* Click on "core.zip and download it, then extract it into a sub-directory of symbolsrc named cldr
-* Download UnicodeData.txt: (ftp://ftp.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt) and put it into the symbolsrc directory
+* Extract the archive in the locale/symbolsrc sub-directory of your Speech-Dispatcher repository, which will create a nvda-beta folder
+* Download the latest unicode CLDR release by clicking the "core.zip" link on this web page: (https://unicode.org/Public/cldr/latest)
+* Extract the downloaded file into a sub-directory of locale/symbolsrc named cldr
+* Download UnicodeData.txt: (ftp://ftp.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt) and put it into the locale/symbolsrc directory
 * In locale, type:
 ```
 make import-symbols

--- a/locale/symbolsrc/.gitignore
+++ b/locale/symbolsrc/.gitignore
@@ -1,0 +1,3 @@
+nvda-beta
+UnicodeData.txt
+cldr


### PR DESCRIPTION
* Provide a more direct link to last CLDR release and update instructions
* Create the locale/symbolsrc directory and put a .gitignore into it
