### PR TITLE
Fix G_ENCODE_VERSION for unstable 2.67 versions

### DIFF
--- a/src/common/speak_queue.c
+++ b/src/common/speak_queue.c
@@ -239,7 +239,7 @@ module_speak_queue_add_audio(const AudioTrack *track, AudioFormat format)
 	playback_queue_entry->type = SPEAK_QUEUE_QET_AUDIO;
 	playback_queue_entry->data.audio.track = *track;
 	gint nbytes = track->bits / 8 * track->num_samples;
-#if GLIB_VERSION_CUR_STABLE >= G_ENCODE_VERSION(2, 68)
+#if G_ENCODE_VERSION(GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= G_ENCODE_VERSION(2, 68)
 	playback_queue_entry->data.audio.track.samples = g_memdup2(track->samples, nbytes);
 #else
 	playback_queue_entry->data.audio.track.samples = g_memdup(track->samples, nbytes);


### PR DESCRIPTION
Issue is the way stable an unstable are handled in glib.  Unstable versions are not considered as 2.67, but as 2.68.

g_memdup2 was not available in all of the 2.67.y releases.

Reported at https://forum.libreelec.tv/thread/26241-problem-building-package-on-libreelec-10/

Signed-off-by: Rudi Heitbaum <rudi@heitbaum.com>