### PR TITLE
espeak: set buffer size to 300

### DIFF
--- a/config/modules/espeak-ng-mbrola.conf
+++ b/config/modules/espeak-ng-mbrola.conf
@@ -41,7 +41,7 @@ EspeakMaxRate 449
 # -- Internal parameters --
 
 # Number of ms of audio returned by the espeak callback function.
-EspeakAudioChunkSize 3000
+EspeakAudioChunkSize 300
 
 # Maximum number of samples to buffer in playback queue.
 EspeakAudioQueueMaxSize 441000

--- a/config/modules/espeak-ng.conf
+++ b/config/modules/espeak-ng.conf
@@ -41,7 +41,7 @@ EspeakMaxRate 449
 # -- Internal parameters --
 
 # Number of ms of audio returned by the espeak callback function.
-EspeakAudioChunkSize 3000
+EspeakAudioChunkSize 300
 
 # Maximum number of samples to buffer in playback queue.
 EspeakAudioQueueMaxSize 441000

--- a/config/modules/espeak.conf
+++ b/config/modules/espeak.conf
@@ -41,7 +41,7 @@ EspeakMaxRate 449
 # -- Internal parameters --
 
 # Number of ms of audio returned by the espeak callback function.
-EspeakAudioChunkSize 3000
+EspeakAudioChunkSize 300
 
 # Maximum number of samples to buffer in playback queue.
 EspeakAudioQueueMaxSize 441000


### PR DESCRIPTION
this fixes #793
ref for buffer size: https://github.com/nvaccess/nvda/blob/a6fb2392083b5fa1bae926102135ad452746ad3c/source/synthDrivers/_espeak.py#L338
