### PR TITLE
python: Fix checking all lines of a message have the same code

### DIFF
--- a/src/api/python/speechd/client.py
+++ b/src/api/python/speechd/client.py
@@ -283,6 +283,7 @@ class _SSIP_Connection(object):
             if sep == ' ':
                 msg = text
                 return int(code), msg, tuple(data)
+            c = code
             data.append(text)
 
     def _recv_response(self):


### PR DESCRIPTION
This is something that was lost back in 2003 in commit c71d08a1de6888f8be6a007303d18bd8bcce8c65.

This is merely a missing validation, but the code looks very strange as it was, trying to perform the validation but having it not actually do anything.

---

Disclaimer: I didn't actually test this very much, and possibly the extra validation would show bugs elsewhere.  However, I do think something should be fixed in this area: either have fully working code, or remove the pieces that pretend to check yet are no-ops.