### PR TITLE
Add missing end event in audio queue

### DIFF
--- a/src/server/output.c
+++ b/src/server/output.c
@@ -991,6 +991,8 @@ static int output_module_is_speaking(OutputModule * output)
 				MSG(4, "we sent PAUSE too late, now tell the speak queue");
 				if (!output_pause_queued)
 					module_speak_queue_pause();
+				if (!module_speak_queue_add_end())
+					MSG(3, "Warning: couldn't add end to speak queue");
 			} else {
 				if (!module_speak_queue_add_end())
 					MSG(3, "Warning: couldn't add end to speak queue");


### PR DESCRIPTION
In the case of a pause request during some audio without any index, we still need to inject an end event, and we'll notice the pause there

Fixes #813