### PR TITLE
Add missing end event in audio queue

### DIFF
--- a/src/server/output.c
+++ b/src/server/output.c
@@ -1022,6 +1022,8 @@ static int output_module_is_speaking(OutputModule * output)
 		if (output->audio) {
 			if (!output_pause_queued)
 				module_speak_queue_pause();
+			if (!module_speak_queue_add_end())
+				MSG(3, "Warning: couldn't add end to speak queue");
 		} else
 			module_report_event_pause();
 		retcode = 0;


### PR DESCRIPTION
In the case of a pause request during some long speak, the module will report as paused. We then again (see 8bead4f21721 "Add missing end event in audio queue") still need to inject an end event, and we'll notice the pause there.

Fixes #813