### PR TITLE
Update documentation for symbols importation

### DIFF
--- a/locale/README.md
+++ b/locale/README.md
@@ -2,11 +2,11 @@
 
 * Get gettext version 0.20 or later
 * Install the latest version of orca master by hand
-* Download NVDA sources using this link: (https://github.com/nvaccess/nvda/archive/beta.zip)
+* Download NVDA sources using this link: https://github.com/nvaccess/nvda/archive/beta.zip
 * Extract the archive in the locale/symbolsrc sub-directory of your Speech-Dispatcher repository, which will create a nvda-beta folder
-* Download the latest unicode CLDR release by clicking the "core.zip" link on this web page: (https://unicode.org/Public/cldr/latest)
+* Download the latest unicode CLDR release by clicking the `"cldr-common-<version>.zip"` link on this web page: https://unicode.org/Public/cldr/latest
 * Extract the downloaded file into a sub-directory of locale/symbolsrc named cldr
-* Download UnicodeData.txt: (ftp://ftp.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt) and put it into the locale/symbolsrc directory
+* Download UnicodeData.txt: ftp://ftp.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt and put it into the locale/symbolsrc directory
 * In locale, type:
 ```
 make import-symbols


### PR DESCRIPTION
* Change the name of the link to click to download the CLDR zip file
* Remove markdown for links which are not displayed as expected
