### PR TITLE
client library: fix buffering

### DIFF
--- a/src/api/c/libspeechd.c
+++ b/src/api/c/libspeechd.c
@@ -89,8 +89,8 @@ struct SPDConnection_threaddata {
 };
 
 /*
- * Added by Willie Walker - strndup and getline were GNU libc extensions
- * that were adopted in the POSIX.1-2008 standard, but are not yet found
+ * Added by Willie Walker - strndup was a GNU libc extensions
+ * that was adopted in the POSIX.1-2008 standard, but is not yet found
  * on all systems.
  */
 #ifndef HAVE_STRNDUP
@@ -114,52 +114,64 @@ char *strndup(const char *s, size_t n)
 }
 #endif /* HAVE_STRNDUP */
 
-#ifndef HAVE_GETLINE
-#define BUFFER_LEN 256
-ssize_t getline(char **lineptr, size_t * n, FILE * f)
-{
-	int ch;
-	size_t m = 0;
-	ssize_t buf_len = 0;
-	char *buf = NULL;
-	char *p = NULL;
+#define SPD_REPLY_BUF_SIZE 65536
 
-	if (errno != 0) {
-		SPD_DBG("getline: errno came in as %d!!!\n", errno);
-		errno = 0;
-	}
-	while ((ch = getc(f)) != EOF) {
-		if (errno != 0)
-			return -1;
-		if (m++ >= buf_len) {
-			buf_len += BUFFER_LEN;
-			buf = (char *)realloc(buf, buf_len + 1);
-			if (buf == NULL) {
-				SPD_DBG("buf==NULL");
-				return -1;
+/** Read from the connection's buffer or socket until a newline is
+    read.  Return a pointer to the beginning of the data, and the
+    length of the data (including newline).  The returned value will
+    not be null-terminated, and will include the newline.  Note that
+    the returned pointer will only be valid until the next call to
+    get_line.
+
+    If, after SPD_REPLY_BUF_SIZE bytes, there is no newline (or in the
+    event of a read error) return NULL.
+
+    Unlike getline, this does not handle embedded \0 bytes.
+*/
+char *get_line(SPDConnection * conn, int *n)
+{
+	int bytes;
+	int i;
+	char *ret = NULL;
+	int search_start = conn->buf_start;
+	int message_prefix_len;
+
+	while (1) {
+		for (i = search_start; i < conn->buf_used; i++) {
+			if (conn->buf[i] == '\n') {
+				*n = i + 1 - conn->buf_start;
+				ret = conn->buf + conn->buf_start;
+				conn->buf_start = i + 1;
+				return ret;
 			}
-			p = buf + buf_len - BUFFER_LEN;
 		}
-		*p = ch;
-		p++;
-		if (ch == '\n')
-			break;
+
+		if (conn->buf_start != 0) {
+			message_prefix_len = conn->buf_used - conn->buf_start;
+			memmove(conn->buf, conn->buf + conn->buf_start,
+				message_prefix_len);
+			search_start = message_prefix_len;
+			conn->buf_used = message_prefix_len;
+			conn->buf_start = 0;
+		}
+
+		if (conn->buf_used == SPD_REPLY_BUF_SIZE) {
+			SPD_FATAL
+			    ("No newline after reading SPD_REPLY_BUF_SIZE");
+			return NULL;
+		}
+
+		bytes =
+		    read(conn->socket, conn->buf + conn->buf_used,
+			 SPD_REPLY_BUF_SIZE - conn->buf_used);
+		if (bytes == -1)
+			return NULL;
+		conn->buf_used += bytes;
 	}
-	if (m == 0) {
-		SPD_DBG("getline: m=%d!", m);
-		return -1;
-	} else {
-		*p = '\0';
-		*lineptr = buf;
-		*n = m;
-		return m;
-	}
+
 }
-#endif /* HAVE_GETLINE */
 
 /* --------------------- Public functions ------------------------- */
-
-#define SPD_REPLY_BUF_SIZE 65536
 
 /* Determine address for the unix socket */
 static char *_get_default_unix_socket_name(void)
@@ -537,14 +549,20 @@ SPDConnection *spd_open2(const char *client_name, const char *connection_name,
 
 	connection->mode = mode;
 
-	/* Create a stream from the socket */
-	connection->stream = fdopen(connection->socket, "r");
-	if (!connection->stream)
-		SPD_FATAL("Can't create a stream for socket, fdopen() failed.");
-	/* Switch to line buffering mode */
-	ret = setvbuf(connection->stream, NULL, _IONBF, SPD_REPLY_BUF_SIZE);
-	if (ret)
-		SPD_FATAL("Can't set buffering, setvbuf failed.");
+	/* Set up buffer for the socket */
+	connection->buf_start = 0;
+	connection->buf_used = 0;
+	connection->buf = malloc(SPD_REPLY_BUF_SIZE);
+
+	if (!connection->buf) {
+		*error_result =
+		    strdup("Out of memory allocating connection buffer");
+		SPD_DBG(*error_result);
+		close(connection->socket);
+		free(connection);
+		connection = NULL;
+		goto out;
+	}
 
 	pthread_mutex_init(&connection->ssip_mutex, NULL);
 
@@ -562,7 +580,8 @@ SPDConnection *spd_open2(const char *client_name, const char *connection_name,
 		if (ret != 0) {
 			*error_result = strdup("Thread initialization failed");
 			SPD_DBG(*error_result);
-			fclose(connection->stream);
+			close(connection->socket);
+			free(connection->buf);
 			free(connection);
 			connection = NULL;
 			goto out;
@@ -620,11 +639,11 @@ void spd_close(SPDConnection * connection)
 	}
 
 	/* close the socket */
-	if (connection->stream != NULL) {
-		fclose(connection->stream);
-		connection->stream = NULL;
+	if (connection->socket >= 0) {
+		close(connection->socket);
 		connection->socket = -1;
 	}
+	free(connection->buf);
 
 	pthread_mutex_unlock(&connection->ssip_mutex);
 
@@ -1788,25 +1807,22 @@ static int spd_set_priority(SPDConnection * connection, SPDPriority priority)
 
 struct get_reply_data {
 	GString *str;
-	char *line;
 };
 
 static void get_reply_cleanup(void *arg)
 {
 	struct get_reply_data *data = arg;
 	g_string_free(data->str, TRUE);
-	free(data->line);
 }
 
 static char *get_reply(SPDConnection * connection)
 {
-	size_t N = 0;
-	int bytes;
 	char *reply;
+	char *line;
+	int n;
 	gboolean errors = FALSE;
 	struct get_reply_data data;
 
-	data.line = NULL;
 	data.str = g_string_new("");
 
 	pthread_cleanup_push(get_reply_cleanup, &data);
@@ -1814,26 +1830,22 @@ static char *get_reply(SPDConnection * connection)
 	/* Wait for activity on the socket, when there is some,
 	   read all the message line by line */
 	do {
-		bytes = getline(&data.line, &N, connection->stream);
-		if (bytes == -1) {
+		line = get_line(connection, &n);
+		if (line == NULL) {
 			SPD_DBG
 			    ("Error: Can't read reply, broken socket in get_reply!");
-			if (connection->stream != NULL)
-			{
-				fclose(connection->stream);
-				connection->stream = NULL;
+			if (connection->socket >= 0) {
+				close(connection->socket);
 				connection->socket = -1;
 			}
 			errors = TRUE;
 		} else {
-			g_string_append(data.str, data.line);
+			g_string_append_len(data.str, line, n);
 		}
 		/* terminate if we reached the last line (without '-' after numcode) */
-	} while (!errors && !((strlen(data.line) < 4) || (data.line[3] == ' ')));
+	} while (!errors && n >= 4 && line[3] != ' ');
 
 	pthread_cleanup_pop(0);
-
-	free(data.line);		/* getline allocates with malloc. */
 
 	if (errors) {
 		/* Free the GString and its character data, and return NULL. */
@@ -1958,9 +1970,8 @@ static void *spd_events_handler(void *conn)
 	/* In case of broken socket, we must still signal reply ready */
 	if (connection->reply == NULL) {
 		SPD_DBG("Signalling reply ready after communication failure");
-		if (connection->stream != NULL) {
-			fclose(connection->stream);
-			connection->stream = NULL;
+		if (connection->socket >= 0) {
+			close(connection->socket);
 			connection->socket = -1;
 		}
 		pthread_cond_signal(&connection->td->cond_reply_ready);

--- a/src/api/c/libspeechd.h
+++ b/src/api/c/libspeechd.h
@@ -86,8 +86,10 @@ typedef struct {
 
 	/* PRIVATE */
 	int socket;
-	FILE *stream;
 	SPDConnectionMode mode;
+	char *buf;
+	size_t buf_start;
+	size_t buf_used;
 
 	pthread_mutex_t ssip_mutex;
 


### PR DESCRIPTION
In ec25ad9, buffering was switched from line buffering to character buffering.  This caused slow performance when large amounts of data are transferred. Instead, make each connection maintain a buffer of size SPD_REPLY_BUF_SIZE.

For me, this improves the performance of `spd-say -L > /dev/null` from 0.5s to 0.35s.

This might also fix #750, or perhaps we will also need to fix the server side as well.

Fixes #833