### PR TITLE
Add *.zip to local/symbolsrc/.gitignore

### DIFF
--- a/locale/symbolsrc/.gitignore
+++ b/locale/symbolsrc/.gitignore
@@ -1,3 +1,4 @@
 nvda-beta
 UnicodeData.txt
 cldr
+*.zip


### PR DESCRIPTION
CLDR and NVDA beta are zip files and can be ignored by git.
