### PR TITLE
Simplify g_string_free(foo, FALSE) calls

### DIFF
--- a/src/api/c/libspeechd.c
+++ b/src/api/c/libspeechd.c
@@ -1865,9 +1865,8 @@ static char *get_reply(SPDConnection * connection)
 		reply = NULL;
 	} else {
 		/* The resulting message received from the socket is stored in reply */
-		reply = data.str->str;
 		/* Free the GString, but not its character data. */
-		g_string_free(data.str, FALSE);
+		reply = g_string_free(data.str, FALSE);
 	}
 
 	return reply;

--- a/src/modules/festival.c
+++ b/src/modules/festival.c
@@ -222,8 +222,7 @@ int module_load(void)
 }
 
 #define ABORT(msg) g_string_append(info, msg); \
-	*status_info = info->str; \
-	g_string_free(info, 0); \
+	*status_info = g_string_free(info, 0); \
 	return -1;
 
 int module_init(char **status_info)
@@ -277,8 +276,7 @@ int module_init(char **status_info)
 
 	festival_speaking = 0;
 
-	*status_info = info->str;
-	g_string_free(info, 0);
+	*status_info = g_string_free(info, 0);
 
 	return 0;
 }

--- a/src/modules/ibmtts.c
+++ b/src/modules/ibmtts.c
@@ -1418,8 +1418,7 @@ static char *search_for_sound_icon(const char *icon_name)
 	 * situation the string filename must be freed, including its character
 	 * data.
 	 */
-	g_string_free(filename, (fn == NULL));
-	return fn;
+	return g_string_free(filename, (fn == NULL));
 }
 
 #ifdef VOXIN

--- a/src/server/history.c
+++ b/src/server/history.c
@@ -50,7 +50,6 @@ char *history_get_client_list()
 	TFDSetElement *client;
 	GString *clist;
 	int i;
-	char *ret;
 
 	clist = g_string_new("");
 
@@ -67,17 +66,13 @@ char *history_get_client_list()
 	}
 	g_string_append_printf(clist, OK_CLIENT_LIST_SENT);
 
-	ret = clist->str;
-	g_string_free(clist, FALSE);
-
-	return ret;
+	return g_string_free(clist, FALSE);
 }
 
 char *history_get_client_id(int fd)
 {
 	GString *cid;
 	int uid;
-	char *ret;
 
 	uid = get_client_uid_by_fd(fd);
 	if (uid == 0)
@@ -86,10 +81,8 @@ char *history_get_client_id(int fd)
 	cid = g_string_new("");
 	g_string_append_printf(cid, C_OK_CLIENT_ID "-%d\r\n", uid);
 	g_string_append_printf(cid, OK_CLIENT_ID_SENT);
-	ret = cid->str;
-	g_string_free(cid, FALSE);
 
-	return ret;
+	return g_string_free(cid, FALSE);
 }
 
 char *history_get_message(int uid)
@@ -142,7 +135,6 @@ char *history_get_message_list(guint client_id, int from, int num)
 	TFDSetElement *client_settings;
 	GList *client_msgs;
 	int i;
-	char *ret;
 
 	MSG(4, "message_list: from %d num %d, client %d\n", from, num,
 	    client_id);
@@ -159,9 +151,7 @@ char *history_get_message_list(guint client_id, int from, int num)
 		gl = g_list_nth(client_msgs, i);
 		if (gl == NULL) {
 			g_string_append_printf(mlist, OK_MSGS_LIST_SENT);
-			ret = mlist->str;
-			g_string_free(mlist, FALSE);
-			return ret;
+			return g_string_free(mlist, FALSE);
 		}
 		message = gl->data;
 
@@ -178,9 +168,8 @@ char *history_get_message_list(guint client_id, int from, int num)
 	}
 
 	g_string_append_printf(mlist, OK_MSGS_LIST_SENT);
-	ret = mlist->str;
-	g_string_free(mlist, FALSE);
-	return ret;
+
+	return g_string_free(mlist, FALSE);
 }
 
 char *history_get_last(int fd)
@@ -188,7 +177,6 @@ char *history_get_last(int fd)
 	TSpeechDMessage *message;
 	GString *lastm;
 	GList *gl;
-	char *ret;
 
 	gl = g_list_last(message_history);
 	if (gl == NULL)
@@ -198,9 +186,8 @@ char *history_get_last(int fd)
 	lastm = g_string_new("");
 	g_string_append_printf(lastm, C_OK_LAST_MSG "-%d\r\n", message->id);
 	g_string_append_printf(lastm, OK_LAST_MSG);
-	ret = lastm->str;
-	g_string_free(lastm, FALSE);
-	return ret;
+
+	return g_string_free(lastm, FALSE);
 }
 
 char *history_cursor_set_last(int fd, guint client_id)
@@ -292,7 +279,6 @@ char *history_cursor_get(int fd)
 	TSpeechDMessage *new;
 	GString *reply;
 	GList *gl, *client_msgs;
-	char *ret;
 
 	settings = get_client_settings_by_fd(fd);
 	if (settings == NULL)
@@ -306,9 +292,8 @@ char *history_cursor_get(int fd)
 
 	reply = g_string_new("");
 	g_string_printf(reply, C_OK_CUR_POS "-%d\r\n" OK_CUR_POS_RET, new->id);
-	ret = reply->str;
-	g_string_free(reply, FALSE);
-	return ret;
+
+	return g_string_free(reply, FALSE);
 }
 
 char *history_say_id(int fd, int id)

--- a/src/server/index_marking.c
+++ b/src/server/index_marking.c
@@ -120,9 +120,7 @@ void insert_index_marks(TSpeechDMessage * msg, SPDDataMode ssml_mode)
 		g_string_append_printf(marked_text, "</speak>");
 
 	g_free(msg->buf);
-	msg->buf = marked_text->str;
-
-	g_string_free(marked_text, 0);
+	msg->buf = g_string_free(marked_text, 0);
 
 	MSG2(5, "index_marking", "MSG after index marking: |%s|", msg->buf);
 }
@@ -196,8 +194,7 @@ char *strip_index_marks(const char *buf, SPDDataMode ssml_mode)
 			*p_str = 0;
 	}
 
-	strret = str->str;
-	g_string_free(str, 0);
+	strret = g_string_free(str, 0);
 
 	MSG2(5, "index_marking", "Message after stripping index marks: |%s|",
 	     strret);

--- a/src/server/output.c
+++ b/src/server/output.c
@@ -1493,8 +1493,7 @@ char *escape_dot(char *otext)
 		ret = otext;
 	} else {
 		g_string_append(ntext, otext);
-		ret = ntext->str;
-		g_string_free(ntext, 0);
+		ret = g_string_free(ntext, 0);
 	}
 
 	MSG2(6, "escaping", "Altered text: |%s|", ret);

--- a/src/server/parse.c
+++ b/src/server/parse.c
@@ -69,7 +69,6 @@ char *parse(const char *buf, const int bytes, const int fd)
 	int reparted;
 	int msg_uid;
 	GString *ok_queued_reply;
-	char *reply;
 	TSpeechDSock *speechd_socket = speechd_socket_get_by_fd(fd);
 	assert(speechd_socket);
 
@@ -201,9 +200,7 @@ enddata:
 			g_string_printf(ok_queued_reply,
 					C_OK_MESSAGE_QUEUED "-%d" NEWLINE
 					OK_MESSAGE_QUEUED, msg_uid);
-			reply = ok_queued_reply->str;
-			g_string_free(ok_queued_reply, 0);
-			return reply;
+			return g_string_free(ok_queued_reply, 0);
 		}
 
 		{
@@ -931,7 +928,6 @@ char *parse_list(const char *buf, const int bytes, const int fd,
 		return voice_list;
 	} else if (TEST_CMD(list_type, "output_modules")) {
 		GString *result = g_string_new("");
-		char *helper;
 		OutputModule *mod;
 		int i, len;
 
@@ -946,17 +942,13 @@ char *parse_list(const char *buf, const int bytes, const int fd,
 		}
 
 		g_string_append(result, OK_MODULES_LIST_SENT);
-		helper = result->str;
-		g_string_free(result, 0);
-
-		return helper;
+		return g_string_free(result, 0);
 	} else if (TEST_CMD(list_type, "synthesis_voices")) {
 		int uid;
 		TFDSetElement *settings;
 		SPDVoice **voices;
 		GString *result;
 		int i;
-		char *helper;
 		char *language;
 		char *variant;
 
@@ -989,10 +981,8 @@ char *parse_list(const char *buf, const int bytes, const int fd,
 			g_free(voices[i]);
 		}
 		g_string_append(result, OK_VOICE_LIST_SENT);
-		helper = result->str;
-		g_string_free(result, 0);
 		g_free(voices);
-		return helper;
+		return g_string_free(result, 0);
 	} else {
 		g_free(list_type);
 		return g_strdup(ERR_PARAMETER_INVALID);
@@ -1004,7 +994,6 @@ char *parse_get(const char *buf, const int bytes, const int fd,
 {
 	char *get_type;
 	GString *result;
-	char *helper;
 
 	TFDSetElement *settings;
 
@@ -1072,9 +1061,7 @@ char *parse_get(const char *buf, const int bytes, const int fd,
 		g_free(get_type);
 		g_string_append(result, ERR_PARAMETER_INVALID);
 	}
-	helper = result->str;
-	g_string_free(result, 0);
-	return helper;
+	return g_string_free(result, 0);
 }
 
 char *parse_help(const char *buf, const int bytes, const int fd,

--- a/src/server/symbols.c
+++ b/src/server/symbols.c
@@ -256,7 +256,6 @@ static gchar *escape_ssml_text(const gchar *text, struct tags **tags_ret, gint *
 	const gchar *cur, *curtag = NULL;
 	struct tags *tags;
 	GString *str;
-	gchar *result;
 	gchar name[7];		/* Current tag name, only need to recognize against "mark", "/mark", "!--" for now */
 	gsize namepos = 0;
 
@@ -408,10 +407,7 @@ static gchar *escape_ssml_text(const gchar *text, struct tags **tags_ret, gint *
 	*tags_ret = tags;
 	*ntags_ret = ntags;
 
-	result = str->str;
-	g_string_free(str, FALSE);
-
-	return result;
+	return g_string_free(str, FALSE);
 }
 
 /* Put back tags into the text */
@@ -419,7 +415,6 @@ static gchar *unescape_ssml_text(const gchar *text, struct tags *tags, gint ntag
 {
 	GString *str;
 	const gchar *cur;
-	gchar *result;
 	struct tags *curtags = tags;
 
 	str = g_string_sized_new(strlen(text));
@@ -460,10 +455,7 @@ static gchar *unescape_ssml_text(const gchar *text, struct tags *tags, gint ntag
 
 	free(tags);
 
-	result = str->str;
-	g_string_free(str, FALSE);
-
-	return result;
+	return g_string_free(str, FALSE);
 }
 
 /*----------------- Speech symbol representation and loading ----------------*/


### PR DESCRIPTION
g_string_free conveniently returns the C pointer, and newer versions actually warn if we don't do pick it up.