### PR TITLE
Make the fallback espeak-ng and dummy modules hardcoded

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ Version 0.12 (unreleased)
 * Update CLDR to version 44 and symbols from NVDA.
 * Add spd_fd function to C api.
 * Detect module failures from generic module.
+* Make the fallback espeak-ng and dummy modules hardcoded.
 
 Version 0.11.5
 * Update CLDR to version 43 and symbols from NVDA.

--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -274,11 +274,6 @@ SymbolsPreprocFile "orca-chars.dic"
 #AddModule "rhvoice"                  "sd_rhvoice"   "rhvoice.conf"
 #AddModule "voxin"                    "sd_voxin"     "voxin.conf"
 
-# DO NOT REMOVE the following line unless you have
-# a specific reason -- this is the fallback output module
-# that is only used when no other modules are in use
-#AddModule "dummy"         "sd_dummy"      ""
-
 # The output module testing doesn't actually connect to anything. It
 # outputs the requested commands to standard output and reads
 # responses from stdandard input. This way, Speech Dispatcher's
@@ -332,7 +327,7 @@ Include "clients/*.conf"
 # Copyright (C) 2017 Colomban Wendling <cwendling@hypra.fr>
 # Copyright (C) 2018 Raphaël POITEVIN <rpoitevin@hypra.fr>
 # Copyright (C) 2018 Florian Steinhardt <no.known.email@example.com>
-# Copyright (C) 2018-2021, 2023 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2018-2024 Samuel Thibault <samuel.thibault@ens-lyon.org>
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software

--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -816,6 +816,28 @@ static gboolean speechd_load_configuration(gpointer user_data)
 				    g_list_delete_link(detected_modules,
 						       detected_modules);
 			}
+		} else {
+			/* Try to make sure we have something that can speak (with no user parameter) */
+			module_add_load_request(
+					g_strdup("espeak-ng-fallback"),
+					g_strdup("sd_espeak-ng"),
+					NULL,
+					g_strdup_printf("%s/%s.log",
+							SpeechdOptions.log_dir,
+							"espeak-ng"),
+					NULL,
+					NULL);
+
+			/* At worse, tell what is happening */
+			module_add_load_request(
+					g_strdup("dummy"),
+					g_strdup("sd_dummy"),
+					NULL,
+					g_strdup_printf("%s/%s.log",
+							SpeechdOptions.log_dir,
+							"dummy"),
+					NULL,
+					NULL);
 		}
 
 		module_load_requested_modules();


### PR DESCRIPTION
So that users cannot shoot themselves into the foot by only enabling a module that happens not to be working.