### PR TITLE
Also load espeak-ng-fallback and dummy on autodetection

### DIFF
--- a/src/server/parse.c
+++ b/src/server/parse.c
@@ -935,6 +935,7 @@ char *parse_list(const char *buf, const int bytes, const int fd,
 		for (i = 0; i < len; i++) {
 			mod = g_list_nth_data(output_modules, i);
 			if (strcmp(mod->name, "dummy") &&
+			    strcmp(mod->name, "espeak-ng-fallback") &&
 			    strcmp(mod->name, "generic"))
 				g_string_append_printf(result, C_OK_MODULES
 						       "-%s" NEWLINE,

--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -816,29 +816,29 @@ static gboolean speechd_load_configuration(gpointer user_data)
 				    g_list_delete_link(detected_modules,
 						       detected_modules);
 			}
-		} else {
-			/* Try to make sure we have something that can speak (with no user parameter) */
-			module_add_load_request(
-					g_strdup("espeak-ng-fallback"),
-					g_strdup("sd_espeak-ng"),
-					NULL,
-					g_strdup_printf("%s/%s.log",
-							SpeechdOptions.log_dir,
-							"espeak-ng"),
-					NULL,
-					NULL);
-
-			/* At worse, tell what is happening */
-			module_add_load_request(
-					g_strdup("dummy"),
-					g_strdup("sd_dummy"),
-					NULL,
-					g_strdup_printf("%s/%s.log",
-							SpeechdOptions.log_dir,
-							"dummy"),
-					NULL,
-					NULL);
 		}
+
+		/* Try to make sure we have something that can speak (with no user parameter) */
+		module_add_load_request(
+				g_strdup("espeak-ng-fallback"),
+				g_strdup("sd_espeak-ng"),
+				g_strdup(""),
+				g_strdup_printf("%s/%s.log",
+						SpeechdOptions.log_dir,
+						"espeak-ng-fallback"),
+				NULL,
+				NULL);
+
+		/* At worse, tell what is happening */
+		module_add_load_request(
+				g_strdup("dummy"),
+				g_strdup("sd_dummy"),
+				g_strdup(""),
+				g_strdup_printf("%s/%s.log",
+						SpeechdOptions.log_dir,
+						"dummy"),
+				NULL,
+				NULL);
 
 		module_load_requested_modules();
 	} else {


### PR DESCRIPTION
In case the user configuration breaks all modules, we will fallback to espeak-ng without configuration, and at really worse, on dummy.