### PR TITLE
Replace ctime with ctime_r

### DIFF
--- a/src/audio/alsa.c
+++ b/src/audio/alsa.c
@@ -3,7 +3,7 @@
  * alsa.c -- The Advanced Linux Sound System backend for Speech Dispatcher
  *
  * Copyright (C) 2005,2006 Brailcom, o.p.s.
- * Copyright (C) 2019 Samuel Thibault <samuel.thibault@ens-lyon.org>
+ * Copyright (C) 2019-2024 Samuel Thibault <samuel.thibault@ens-lyon.org>
  *
  * This is free software; you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free
@@ -87,9 +87,9 @@ static int wait_for_poll(spd_alsa_id_t * id, struct pollfd *alsa_poll_fds,
 	if(level <= alsa_log_level){ \
 		time_t t; \
 		struct timeval tv; \
-		char *tstr; \
+		char tstr[26]; \
 		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
+		ctime_r(&t, tstr); \
 		tstr[strlen(tstr)-1] = 0; \
 		gettimeofday(&tv,NULL); \
 		fprintf(stderr," %s [%d.%06d]",tstr, (int)tv.tv_sec % 10, (int) tv.tv_usec); \
@@ -97,16 +97,15 @@ static int wait_for_poll(spd_alsa_id_t * id, struct pollfd *alsa_poll_fds,
 		fprintf(stderr,arg); \
 		fprintf(stderr,"\n"); \
 		fflush(stderr); \
-		g_free(tstr); \
 	}
 
 #define ERR(arg...) \
 	{ \
 		time_t t; \
 		struct timeval tv; \
-		char *tstr; \
+		char tstr[26]; \
 		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
+		ctime_r(&t, tstr); \
 		tstr[strlen(tstr)-1] = 0; \
 		gettimeofday(&tv,NULL); \
 		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
@@ -114,7 +113,6 @@ static int wait_for_poll(spd_alsa_id_t * id, struct pollfd *alsa_poll_fds,
 		fprintf(stderr,arg); \
 		fprintf(stderr,"\n"); \
 		fflush(stderr); \
-		g_free(tstr); \
 	}
 
 static int alsa_log_level;

--- a/src/audio/libao.c
+++ b/src/audio/libao.c
@@ -46,9 +46,9 @@
 	if(level <= libao_log_level){ \
 		time_t t; \
 		struct timeval tv; \
-		char *tstr; \
+		char tstr[26]; \
 		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
+		ctime_r(&t, tstr); \
 		tstr[strlen(tstr)-1] = 0; \
 		gettimeofday(&tv,NULL); \
 		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
@@ -56,16 +56,15 @@
 		fprintf(stderr,arg); \
 		fprintf(stderr,"\n"); \
 		fflush(stderr); \
-		g_free(tstr); \
 	}
 
 #define ERR(arg...) \
 	{ \
 		time_t t; \
 		struct timeval tv; \
-		char *tstr; \
+		char tstr[26]; \
 		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
+		ctime_r(&t, tstr); \
 		tstr[strlen(tstr)-1] = 0; \
 		gettimeofday(&tv,NULL); \
 		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
@@ -73,7 +72,6 @@
 		fprintf(stderr,arg); \
 		fprintf(stderr,"\n"); \
 		fflush(stderr); \
-		g_free(tstr); \
 	}
 
 /* AO_FORMAT_INITIALIZER is an ao_sample_format structure with zero values

--- a/src/audio/oss.c
+++ b/src/audio/oss.c
@@ -64,9 +64,9 @@ static int _oss_sync(spd_oss_id_t * id);
 	if(level <= oss_log_level){ \
 		time_t t; \
 		struct timeval tv; \
-		char *tstr; \
+		char tstr[26]; \
 		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
+		ctime_r(&t, tstr); \
 		tstr[strlen(tstr)-1] = 0; \
 		gettimeofday(&tv,NULL); \
 		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
@@ -74,16 +74,15 @@ static int _oss_sync(spd_oss_id_t * id);
 		fprintf(stderr,arg); \
 		fprintf(stderr,"\n"); \
 		fflush(stderr); \
-		g_free(tstr); \
 	}
 
 #define ERR(arg...) \
 	{ \
 		time_t t; \
 		struct timeval tv; \
-		char *tstr; \
+		char tstr[26]; \
 		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
+		ctime_r(&t, tstr); \
 		tstr[strlen(tstr)-1] = 0; \
 		gettimeofday(&tv,NULL); \
 		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
@@ -91,7 +90,6 @@ static int _oss_sync(spd_oss_id_t * id);
 		fprintf(stderr,arg); \
 		fprintf(stderr,"\n"); \
 		fflush(stderr); \
-		g_free(tstr); \
 	}
 
 static int oss_log_level;

--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -89,9 +89,9 @@ static char const *pulse_play_cmd = "paplay -n speech-dispatcher-generic";
 	if(level <= pulse_log_level){ \
 		time_t t; \
 		struct timeval tv; \
-		char *tstr; \
+		char tstr[26]; \
 		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
+		ctime_r(&t, tstr); \
 		tstr[strlen(tstr)-1] = 0; \
 		gettimeofday(&tv,NULL); \
 		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
@@ -99,16 +99,15 @@ static char const *pulse_play_cmd = "paplay -n speech-dispatcher-generic";
 		fprintf(stderr,arg); \
 		fprintf(stderr,"\n"); \
 		fflush(stderr); \
-		g_free(tstr); \
 	}
 
 #define ERR(arg...) \
 	{ \
 		time_t t; \
 		struct timeval tv; \
-		char *tstr; \
+		char tstr[26]; \
 		t = time(NULL); \
-		tstr = g_strdup(ctime(&t)); \
+		ctime_r(&t, tstr); \
 		tstr[strlen(tstr)-1] = 0; \
 		gettimeofday(&tv,NULL); \
 		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
@@ -116,7 +115,6 @@ static char const *pulse_play_cmd = "paplay -n speech-dispatcher-generic";
 		fprintf(stderr,arg); \
 		fprintf(stderr,"\n"); \
 		fflush(stderr); \
-		g_free(tstr); \
 	}
 
 static int _pulse_open(spd_pulse_id_t * id, int sample_rate,

--- a/src/modules/module_utils.c
+++ b/src/modules/module_utils.c
@@ -53,9 +53,9 @@ void MSG(int level, const char *format, ...) {
 		va_list ap;
 		time_t t;
 		struct timeval tv;
-		char *tstr;
+		char tstr[26];
 		t = time(NULL);
-		tstr = g_strdup(ctime(&t));
+		ctime_r(&t, tstr);
 		tstr[strlen(tstr)-1] = 0;
 		gettimeofday(&tv,NULL);
 		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec);
@@ -74,7 +74,6 @@ void MSG(int level, const char *format, ...) {
 			fprintf(CustomDebugFile, "\n");
 			fflush(CustomDebugFile);
 		}
-		g_free(tstr);
 	}
 }
 

--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -189,12 +189,11 @@ void MSG2(int level, const char *kind, const char *format, ...)
 			{
 				/* Print timestamp */
 				time_t t;
-				char *tstr;
+				char tstr[26];
 				struct timeval tv;
 				t = time(NULL);
-				tstr = g_strdup(ctime(&t));
+				ctime_r(&t, tstr);
 				gettimeofday(&tv, NULL);
-				assert(tstr);
 				/* Remove the trailing \n */
 				assert(strlen(tstr) > 1);
 				tstr[strlen(tstr) - 1] = 0;
@@ -214,7 +213,6 @@ void MSG2(int level, const char *kind, const char *format, ...)
 						"[%s : %d] speechd: ", tstr,
 						(int)tv.tv_usec);
 				}
-				g_free(tstr);
 			}
 			for (i = 1; i < level; i++) {
 				if (std_log) {
@@ -269,13 +267,12 @@ void MSG(int level, const char *format, ...)
 			/* Print timestamp */
 			{
 				time_t t;
-				char *tstr;
+				char tstr[26];
 				struct timeval tv;
 				t = time(NULL);
-				tstr = g_strdup(ctime(&t));
+				ctime_r(&t, tstr);
 				gettimeofday(&tv, NULL);
 				/* Remove the trailing \n */
-				assert(tstr);
 				assert(strlen(tstr) > 1);
 				assert((level >= -1) && (level <= 5));
 				tstr[strlen(tstr) - 1] = 0;
@@ -289,7 +286,6 @@ void MSG(int level, const char *format, ...)
 						(int)tv.tv_usec);
 				/*                fprintf(logfile, "[%s : %d] speechd: ",
 				   tstr, (int) tv.tv_usec); */
-				g_free(tstr);
 			}
 
 			for (i = 1; i < level; i++) {


### PR DESCRIPTION
ctime is *not* thread-safe, so we could end up with assertion failure on the ctime being empty.