### PR TITLE
po/hu.po: updated hungarian translation

### DIFF
--- a/po/hu.po
+++ b/po/hu.po
@@ -300,6 +300,8 @@ msgid ""
 "Read text to be spoken on stdin, write it on stdout unchanged, and the\n"
 "corresponding speech through Speech Dispatcher.\n"
 msgstr ""
+"beolvassa a kimondandó szöveget a standard bemenetről, kiírja a standard kimenetre\n"
+"változatlan formában, majd kimondja a megfelelő beszédszintetizátor segítségével.\n"
 
 #: src/clients/say/options.c:136
 #, c-format
@@ -1025,7 +1027,6 @@ msgstr ""
 "Futtassa újra ezt a parancsot, és válassza ki mit szeretne csinálni,\n"
 "vagy olvassa el a -h vagy --help oldalon elérhető gyors súgót."
 
-#, c-format
 #~ msgid "Pipe from stdin to stdout plus Speech Dispatcher\n"
 #~ msgstr ""
 #~ "a kimondandó szöveg átadása a csővezetéken\n"


### PR DESCRIPTION
Hi Anybody,

With near the RC3 release, I updated the po/hu.po hungarian translation file. :-):-)
Only one new message are untranslated previous, but this is done now.
If this is possible, if have a little time please merge this PR into the master branch.

I have got a small question with punctuation dictionary localization related:
In Orca 46.0 version Speech-dispatcher the Espeak-ng module says the „ (u+201e character) with double low quote, and says the u+201d character with double right quote english language text.
Previous, this simbols are right localized In Orca source code the 44.2 version the Orca po/hu.po file, but Orca developers removed or changed I think this simbol handling after the 46.0 version (or before the 46.0 version publication), and this simbols translations perhaps missing.
How can possible importing the previous right localized punctuation character names from the Orca 44 series po file?
For example the u+0022 simbol I now hear with macskaköröm hungarian text, but the Orca translation this simbol is idézőjel hungarian text the 44.2 series version.
Perhaps this translations are comed out with other simbol file (nvda.dic or symbols.dic the proper localization directory).
So, my purpose:
In the case of the Hungarian language of the Speech-dispatcher, I would like to standardize the Hungarian language translations of Orca and other symbols for the texts that were used and defined in the old Orca version 44.2.
It is possible that since some translations come from the NVDA screen reader translator template, some translations from the symbols.dic file, they overrode the translations after Orca version 46.0 for Speech-dispatcher that were previously used by Orka screen reader for version 44.2. :-):-)
If you can suggest a good way, I would start working on this unification under Debian 12, and when I'm ready, I'd open another pull request for this work related.
Is it possible to prevent the .dic files containing translations from being automatically overwritten in the locale/hu subdirectory?
So, if anyway possible importing oldest character and punctuation character translations the Orca 44.2 version the locale/hu/orca-chars.dic and locale/hu/orca.dic, and unifying the other two dictionary files (emojis.dic, symbols.dic), I would like preventing automatic overwriting. :-):-)
If I might be wrong about the correct maintenance of symbol translations, please tell me the correct way so that I can unify the translations only in the Speech-dispatcher.

Kind regards,

Attila