### PR TITLE
generic: Fix message length after stripping ssml

### DIFF
--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -235,7 +235,10 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 
 	/* TODO: use a generic engine for SPELL, CHAR, KEY */
 	if (msgtype == SPD_MSGTYPE_TEXT)
+	{
 		tmp = module_strip_ssml(tmp);
+		bytes = strlen(tmp);
+	}
 
 	module_strip_punctuation_some(tmp, GenericStripPunctChars);
 


### PR DESCRIPTION
module_strip_ssml removes some text, so before passing it to g_convert_with_fallback we need to update the number of bytes.

Fixes #927