### PR TITLE
generic: Fix message recoding

### DIFF
--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -245,7 +245,7 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 	/* Set the appropriate charset */
 	assert(generic_msg_language != NULL);
 	if (generic_msg_language->charset != NULL) {
-		if (!strcasecmp(generic_msg_language->charset, "utf-8")) {
+		if (strcasecmp(generic_msg_language->charset, "utf-8") != 0) {
 			DBG("Recoding from UTF-8 to %s...",
 			    generic_msg_language->charset);
 			newtmp =


### PR DESCRIPTION
6c16359961f4 ("generic: rework message processing") compared charset to utf-8 erroneously.