### PR TITLE
libspeechd: catch end of file

### DIFF
--- a/src/api/c/libspeechd.c
+++ b/src/api/c/libspeechd.c
@@ -168,6 +168,10 @@ char *get_line(SPDConnection * conn, int *n)
 			 SPD_REPLY_BUF_SIZE - conn->buf_used);
 		if (bytes == -1)
 			return NULL;
+		if (bytes == 0) {
+			errno = ECONNRESET;
+			return NULL;
+		}
 		conn->buf_used += bytes;
 	}
 


### PR DESCRIPTION
In case e.g. speech dispatcher crashes, we have to make get_line error out, so the client can notice it and reattempt opening speech dispatcher.