### PR TITLE
Separate out output management for different output modules

### DIFF
--- a/src/server/module.c
+++ b/src/server/module.c
@@ -368,6 +368,14 @@ OutputModule *load_output_module(const char *mod_name, const char *mod_prog,
 	module->configdir = g_strdup(mod_cfg_dir);
 	module->stderr_redirect = -1;
 
+	pthread_mutex_init(&module->read_mutex, NULL);
+	pthread_cond_init(&module->reply_cond, NULL);
+	pthread_cond_init(&module->event_cond, NULL);
+	module->reply = NULL;
+	module->event = NULL;
+	module->reading_message = FALSE;
+	module->waiting_for_reply = FALSE;
+
 	if (module->progdir) {
 		module->filename = (char *)spd_get_path(mod_prog, module->progdir);
 	} else {

--- a/src/server/module.h
+++ b/src/server/module.h
@@ -42,6 +42,13 @@ typedef struct {
 	pid_t pid;
 	int working;
 	AudioID *audio;
+	pthread_mutex_t read_mutex;
+	pthread_cond_t reply_cond;
+	pthread_cond_t event_cond;
+	GString *reply;
+	GString *event;
+	gboolean reading_message;
+	gboolean waiting_for_reply;
 } OutputModule;
 #define AUDIOID_TOOPEN ((AudioID*) (-1))
 


### PR DESCRIPTION
Otherwise:

- we could be mixing up messages and replies across modules

- for instance when a generic module is playing a message, and we are asked to quit, we would be uselessly waiting for the play to end on the generic module while trying to close another module

It does make a lot sense anyway.