### PR TITLE
audio: Fix logging from audio modules in server-side audio

### DIFF
--- a/src/audio/alsa.c
+++ b/src/audio/alsa.c
@@ -44,6 +44,8 @@
 #endif
 #include <spd_audio_plugin.h>
 
+#include "src/common/common.h"
+
 typedef struct {
 	AudioID id;
 	snd_pcm_t *alsa_pcm;	/* identifier of the ALSA device */
@@ -83,37 +85,8 @@ static int wait_for_poll(spd_alsa_id_t * id, struct pollfd *alsa_poll_fds,
 #endif
 
 /* Put a message into the logfile (stderr) */
-#define MSG(level, arg...) \
-	if(level <= alsa_log_level){ \
-		time_t t; \
-		struct timeval tv; \
-		char tstr[26]; \
-		t = time(NULL); \
-		ctime_r(&t, tstr); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d.%06d]",tstr, (int)tv.tv_sec % 10, (int) tv.tv_usec); \
-		fprintf(stderr," ALSA: "); \
-		fprintf(stderr,arg); \
-		fprintf(stderr,"\n"); \
-		fflush(stderr); \
-	}
-
-#define ERR(arg...) \
-	{ \
-		time_t t; \
-		struct timeval tv; \
-		char tstr[26]; \
-		t = time(NULL); \
-		ctime_r(&t, tstr); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
-		fprintf(stderr," ALSA ERROR: "); \
-		fprintf(stderr,arg); \
-		fprintf(stderr,"\n"); \
-		fflush(stderr); \
-	}
+#define MSG(level, arg, ...) if (level <= alsa_log_level) { MSG(0, "ALSA: " arg, ##__VA_ARGS__); }
+#define ERR(arg, ...) MSG(0, "ALSA ERROR: " arg, ##__VA_ARGS__)
 
 static int alsa_log_level;
 static char const *alsa_play_cmd = "aplay";

--- a/src/audio/libao.c
+++ b/src/audio/libao.c
@@ -39,40 +39,14 @@
 #endif
 #include <spd_audio_plugin.h>
 
+#include "src/common/common.h"
+
 /* send a packet of XXX bytes to the sound device */
 #define AO_SEND_BYTES 256
-/* Put a message into the logfile (stderr) */
-#define MSG(level, arg...) \
-	if(level <= libao_log_level){ \
-		time_t t; \
-		struct timeval tv; \
-		char tstr[26]; \
-		t = time(NULL); \
-		ctime_r(&t, tstr); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
-		fprintf(stderr," libao:: "); \
-		fprintf(stderr,arg); \
-		fprintf(stderr,"\n"); \
-		fflush(stderr); \
-	}
 
-#define ERR(arg...) \
-	{ \
-		time_t t; \
-		struct timeval tv; \
-		char tstr[26]; \
-		t = time(NULL); \
-		ctime_r(&t, tstr); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
-		fprintf(stderr," libao ERROR: "); \
-		fprintf(stderr,arg); \
-		fprintf(stderr,"\n"); \
-		fflush(stderr); \
-	}
+/* Put a message into the logfile (stderr) */
+#define MSG(level, arg, ...) if (level <= libao_log_level) { MSG(0, "libao: " arg, ##__VA_ARGS__); }
+#define ERR(arg, ...) MSG(0, "libao ERROR: " arg, ##__VA_ARGS__)
 
 /* AO_FORMAT_INITIALIZER is an ao_sample_format structure with zero values
    in all of its fields.  We can guarantee that the fields of a

--- a/src/audio/oss.c
+++ b/src/audio/oss.c
@@ -46,6 +46,8 @@
 #endif
 #include <spd_audio_plugin.h>
 
+#include "src/common/common.h"
+
 typedef struct {
 	AudioID id;
 	int fd;
@@ -60,37 +62,8 @@ static int _oss_close(spd_oss_id_t * id);
 static int _oss_sync(spd_oss_id_t * id);
 
 /* Put a message into the logfile (stderr) */
-#define MSG(level, arg...) \
-	if(level <= oss_log_level){ \
-		time_t t; \
-		struct timeval tv; \
-		char tstr[26]; \
-		t = time(NULL); \
-		ctime_r(&t, tstr); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
-		fprintf(stderr," OSS: "); \
-		fprintf(stderr,arg); \
-		fprintf(stderr,"\n"); \
-		fflush(stderr); \
-	}
-
-#define ERR(arg...) \
-	{ \
-		time_t t; \
-		struct timeval tv; \
-		char tstr[26]; \
-		t = time(NULL); \
-		ctime_r(&t, tstr); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
-		fprintf(stderr," OSS ERROR: "); \
-		fprintf(stderr,arg); \
-		fprintf(stderr,"\n"); \
-		fflush(stderr); \
-	}
+#define MSG(level, arg, ...) if (level <= oss_log_level) { MSG(0, "OSS: " arg, ##__VA_ARGS__); }
+#define ERR(arg, ...) MSG(0, "OSS ERROR: " arg, ##__VA_ARGS__)
 
 static int oss_log_level;
 static char const *oss_play_cmd = "play";

--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -58,6 +58,8 @@
 #endif
 #include <spd_audio_plugin.h>
 
+#include "src/common/common.h"
+
 typedef struct spd_pa_simple spd_pa_simple;
 
 typedef struct {
@@ -85,38 +87,9 @@ typedef struct {
 static int pulse_log_level;
 static char const *pulse_play_cmd = "paplay -n speech-dispatcher-generic";
 
-#define MSG(level, arg...) \
-	if(level <= pulse_log_level){ \
-		time_t t; \
-		struct timeval tv; \
-		char tstr[26]; \
-		t = time(NULL); \
-		ctime_r(&t, tstr); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
-		fprintf(stderr," Pulse: "); \
-		fprintf(stderr,arg); \
-		fprintf(stderr,"\n"); \
-		fflush(stderr); \
-	}
-
-#define ERR(arg...) \
-	{ \
-		time_t t; \
-		struct timeval tv; \
-		char tstr[26]; \
-		t = time(NULL); \
-		ctime_r(&t, tstr); \
-		tstr[strlen(tstr)-1] = 0; \
-		gettimeofday(&tv,NULL); \
-		fprintf(stderr," %s [%d]",tstr, (int) tv.tv_usec); \
-		fprintf(stderr," Pulse ERROR: "); \
-		fprintf(stderr,arg); \
-		fprintf(stderr,"\n"); \
-		fflush(stderr); \
-	}
-
+/* Put a message into the logfile (stderr) */
+#define MSG(level, arg, ...) if (level <= pulse_log_level) { MSG(0, "Pulse: " arg, ##__VA_ARGS__); }
+#define ERR(arg, ...) MSG(0, "Pulse ERROR: " arg, ##__VA_ARGS__)
 
 /* The following is a copy of pulseaudio's src/pulse/simple.c
  * that was modified to fit our needs: very low-latency playback start and stop,


### PR DESCRIPTION
in modules stderr is fine but in the server we should really be calling MSG which emits in the log. module_utils already does provide a MSG function that emits to stderr for the module-side audio case, actually.