### PR TITLE
Ignore client SSML mode for CHAR and KEY commands

### DIFF
--- a/src/server/server.c
+++ b/src/server/server.c
@@ -121,6 +121,12 @@ queue_message(TSpeechDMessage * new, int fd, int history_flag,
 		new->time = time(NULL);
 
 		new->settings.paused_while_speaking = 0;
+
+		/* Ignore possible SSML mode for anything but TEXT, as it doesn't make
+		 * sense anything else and can cause problems if the message processing
+		 * assumes SSML although it isn't */
+		if (type != SPD_MSGTYPE_TEXT)
+			new->settings.ssml_mode = SPD_DATA_TEXT;
 	}
 	id = new->id;
 


### PR DESCRIPTION
SSML doesn't make sense for those commands, and it can break processing of them.

For example, if a symbol expansion leads to converting it to a TEXT command, it then has to be valid SSML (including surrounding <speak> tags), otherwise a module might not accept it.  If the client is not in SSML mode it worked fine as the input was translated to SSML, but if the client was in that mode the input was still assumed to already be SSML, although it actually wasn't as it's not possible (nor makes sense) to send SSML through CHAR and KEY.

This e.g. broke the Baratinoo module for such symbol expansions (e.g. when "y" is getting translated to "igrèque" to workaround pronunciation issues in some synthesizers).