### PR TITLE
Sort Baratinoo engine higher

### DIFF
--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -695,6 +695,7 @@ static gint modules_compare (gconstpointer a, gconstpointer b)
 	/* This gives the prioritization order of modules, to automatically select the best quality */
 	static const char *modules_order[] = {
 		"voxin",
+		"baratinoo",
 		"ivona",
 		"pico",
 		"pico-generic",


### PR DESCRIPTION
It was missing from the module order list, leading to have it at the very bottom of the list.  Sort it higher so it can be selected by default in more situations.

Sorting position is somewhat arbitrary, I merely listened to samples for Pico, RHVoice and IVONA and deemed Baratinoo better.  I didn't check all other voices because I didn't easily find relevant samples to listen to, but it's unlikely a user has several of these engines that usually either need specific setup or require buying the corresponding non-free software.