### PR TITLE
espeak-ng-mbrola-generic.conf: Avoid missing argument to option 'GenericPunctNone'

### DIFF
--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -40,7 +40,7 @@ GenericSoundIconFolder "/usr/share/sounds/sound-icons/"
 # Note that if an empty string is specified, then $PUNCT will be blank 
 # which is a default situation for espeak.
  
-GenericPunctNone ""
+GenericPunctNone "--punct=\"\""
 GenericPunctSome "--punct=\"()[]{};:\""
 GenericPunctMost "--punct=\"()[]{};:\""
 GenericPunctAll "--punct"


### PR DESCRIPTION
Closes #955