### PR TITLE
Use strchr() instead of deprecated index()

### DIFF
--- a/src/clients/say/say.c
+++ b/src/clients/say/say.c
@@ -131,13 +131,13 @@ int main(int argc, char **argv)
 			printf("Invalid language!\n");
 	} else {
 		char *locale = strdup(setlocale(LC_MESSAGES, NULL));
-		char *dot = index(locale, '.');
+		char *dot = strchr(locale, '.');
 		if (dot)
 			*dot = 0;
-		char *at = index(locale, '@');
+		char *at = strchr(locale, '@');
 		if (at)
 			*at = 0;
-		char *underscore = index(locale, '_');
+		char *underscore = strchr(locale, '_');
 		if (underscore)
 			*underscore = '-';
 		if (spd_set_language(conn, locale))

--- a/src/modules/espeak.c
+++ b/src/modules/espeak.c
@@ -906,7 +906,7 @@ static SPDVoice **espeak_list_synthesis_voices()
 
 			if (!strncmp(identifier, "mb/mb-", 6)) {
 				voicename = g_strdup(identifier + 6);
-				dash = index(voicename, '-');
+				dash = strchr(voicename, '-');
 				if (dash)
 					/* Ignore "-en" language specification */
 					*dash = 0;


### PR DESCRIPTION
Fixes build failures on Solaris with gcc 14 since the legacy index() function is only defined in the legacy strings.h header, but these files only include the standard string.h header which defines the standard strchr() function.

```
../../../src/modules/espeak.c: In function ‘espeak_list_synthesis_voices’:
../../../src/modules/espeak.c:909:40: error: implicit declaration of function ‘index’ [-Wimplicit-function-declaration]
  909 |                                 dash = index(voicename, '-');
      |                                        ^~~~~
../../../src/modules/espeak.c:909:40: warning: incompatible implicit declaration of built-in function ‘index’ [-Wbuiltin-declaration-mismatch]
```