### PR TITLE
Add a run-spd-say script and make run-speechd and run-spd-say able to talk directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@
 /po/stamp-it
 /po/stamp-po
 /py-compile
+/run-spd-say
 /run-speechd
 /so_locations
 /speech-dispatcher.pc

--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ To build and install speech-dispatcher and all of it's components, read the
 file [INSTALL](INSTALL).
 
 
+To try speech-dispatcher without installing it (e.g. to avoid disturbing an
+existing speech-dispatcher instance), you can run
+
+```
+./run-speechd -t 0 -s
+```
+
+and in another terminal run
+
+```
+./run-spd-say foo
+```
+
+
 People
 ------
 

--- a/configure.ac
+++ b/configure.ac
@@ -567,7 +567,8 @@ AM_CONDITIONAL([USE_LIBSYSTEMD], [test "x$use_libsystemd" = "xyes"])
 AM_CONDITIONAL(BUILD_HTML_DOC, [test "$EMAIL" = samuel.thibault@ens-lyon.org])
 
 AC_CONFIG_FILES([Makefile
-		 run-speechd
+                 run-speechd
+                 run-spd-say
                  speech-dispatcher.pc
                  config/Makefile
                  config/clients/Makefile
@@ -591,7 +592,7 @@ AC_CONFIG_FILES([Makefile
                  src/modules/Makefile
                  src/server/Makefile
                  src/tests/Makefile],
-	 	[chmod +x run-speechd])
+                [chmod +x run-speechd run-spd-say])
 AC_OUTPUT
 AC_MSG_NOTICE([output modules to be built are $output_modules])
 AC_MSG_NOTICE([audio methods to be built are $audio_methods])

--- a/run-spd-say.in
+++ b/run-spd-say.in
@@ -1,0 +1,4 @@
+#!/bin/bash
+abs_builddir=@abs_builddir@
+abs_srcdir=@abs_srcdir@
+LD_LIBRARY_PATH=$abs_builddir/src/audio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} SPEECHD_ADDRESS=inet_socket:127.0.0.1:6561 $abs_builddir/src/clients/say/spd-say "$@"

--- a/run-speechd.in
+++ b/run-speechd.in
@@ -1,4 +1,4 @@
 #!/bin/bash
 abs_builddir=@abs_builddir@
 abs_srcdir=@abs_srcdir@
-LD_LIBRARY_PATH=$abs_builddir/src/audio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} $abs_builddir/src/server/speech-dispatcher -C $abs_srcdir/config -m $abs_builddir/src/modules "$@"
+LD_LIBRARY_PATH=$abs_builddir/src/audio${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} $abs_builddir/src/server/speech-dispatcher -C $abs_srcdir/config -m $abs_builddir/src/modules -P $abs_builddir/speech-dispatcher.pid -c inet_socket -p 6561 "$@"


### PR DESCRIPTION
That allows to run the just-built speech-dispatcher and call spd-say on it without having to interfere with an existing installation.