### PR TITLE
Revert "pulse: Set prebuf to min_audio_length instead of tlength"

### DIFF
--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -527,8 +527,9 @@ static int _pulse_open(spd_pulse_id_t * id, int sample_rate,
 
 	/* Set prebuf to one sample so that keys are spoken as soon as typed rather than delayed until the next key pressed */
 	buffAttr.maxlength = (uint32_t) - 1;
-	buffAttr.tlength = (uint32_t) -1;
-	buffAttr.prebuf = (uint32_t) id->pa_min_audio_length * sample_rate * num_channels * bytes_per_sample / 1000;
+	//buffAttr.tlength = (uint32_t)-1; - this is the default, which causes key echo to not work properly.
+	buffAttr.tlength = id->pa_min_audio_length * sample_rate * num_channels * bytes_per_sample / 1000;
+	buffAttr.prebuf = (uint32_t) - 1;
 	buffAttr.minreq = (uint32_t) - 1;
 	buffAttr.fragsize = (uint32_t) - 1;
 


### PR DESCRIPTION
This reverts commit 2ea44ed0c44c4e5ed8987c0c50559cab1fe2c9ee.

Michael Gorse reported some regressions, see

https://mail.gnu.org/archive/html/speechd-discuss/2024-07/msg00000.html