### PR TITLE
Issue #971 Make local copy of speeking_module to ensure it can be tested for NULL

### DIFF
--- a/src/server/output.c
+++ b/src/server/output.c
@@ -960,15 +960,13 @@ static void output_queue_event(speak_queue_entry *entry)
 {
 	char c = 0;
 	int ret;
-	if (!speaking_module)
-		// We were cancelled
-		return;
 	/* Get the output module.  This is done so that we have a local
 	 * copy of the output module as 'speaking_module' could be set
 	 * to NULL in another thread */
 	OutputModule *output = speaking_module;
 	if (output == NULL)
 	{
+		// We were cancelled
 		return;
 	}
 	pthread_mutex_lock(&playback_events_mutex);

--- a/src/server/output.c
+++ b/src/server/output.c
@@ -963,10 +963,18 @@ static void output_queue_event(speak_queue_entry *entry)
 	if (!speaking_module)
 		// We were cancelled
 		return;
+	/* Get the output module.  This is done so that we have a local
+	 * copy of the output module as 'speaking_module' could be set
+	 * to NULL in another thread */
+	OutputModule *output = speaking_module;
+	if (output == NULL)
+	{
+		return;
+	}
 	pthread_mutex_lock(&playback_events_mutex);
 	playback_events = g_slist_append(playback_events, entry);
 	pthread_mutex_unlock(&playback_events_mutex);
-	ret = write(speaking_module->pipe_speak[1], &c, 1);
+	ret = write(output->pipe_speak[1], &c, 1);
 	if (ret != 1)
 		MSG(1, "Warning: couldn't write to pipe_speak: %d returned, (errno = %d, %s)\n", ret, errno, strerror(errno));
 }


### PR DESCRIPTION
The `speak` thread can change the `speeking_module` to NULL while we are in this function.  So even though `speeking_module` is tested for NULL, this is not good enough in a multi-threading environment.

This change grabs a local copy of `speeking_module` and then tests that for NULL so that even if a thread context switch were to occur and `speeking_module` is set to NULL, the local copy will remain stable and usable.