### PR TITLE
espeak-ng-mbrola-generic: Fix missing sound at the end of messages

### DIFF
--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -22,13 +22,13 @@ Debug 0
 # can modify this value, see other parameters).
 # The command can be split into more lines, if necessary, using '\'.
 GenericExecuteSynth \
-"printf %s \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -q --stdin --pho | mbrola -v $VOLUME -e /usr/share/mbrola/$VOICE/$VOICE - -.au | $PLAY_COMMAND"
+"printf \'%s \' \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -q --stdin --pho | mbrola -v $VOLUME -e /usr/share/mbrola/$VOICE/$VOICE - -.au | $PLAY_COMMAND"
 
 # Alternatively you can shorten the command like below, which makes it
 # work directly with any audio playback utility, but then you won't
 # be able to change the volume from the client application:
 # GenericExecuteSynth \
-# "printf %s \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -stdin"
+# "printf \'%s \' \'$DATA\' | espeak-ng -v mb-$VOICE -s $RATE -p $PITCH $PUNCT -stdin"
 
 GenericCmdDependency "espeak-ng"
 GenericCmdDependency "mbrola"


### PR DESCRIPTION
At least espeak-ng 1.51 from Debian and Ubuntu eat the last character from stdin, so we need to pad with a safe dummy for the whole expected input to be processed.

All is good with espeak (non-ng) 1.48.15:

```shell
$ printf %s 'Bonjour' | espeak -v mb-fr1 -s 160 -p 50  -q --stdin --pho
b	70
o~	41	 0 94 20 95 40 96 59 97 80 99 100 99
Z	70
u	74	 0 102 80 76 100 76
R	70
_	350
_	1
```

But not so much with espeak-ng 1.51:

```shell
$ printf %s 'Bonjour' | espeak-ng -v mb-fr1 -s 160 -p 50  -q --stdin --pho
b	70
o~	41	 0 94 20 95 40 96 59 97 80 99 100 99
Z	70
u	120	 0 102 80 76 100 76
_	350
_	1
```

Notice the missing `R`.

Now, if we pad the input with a single space:

```shell
$ printf '%s ' 'Bonjour' | espeak-ng -v mb-fr1 -s 160 -p 50  -q --stdin --pho
b	70
o~	41	 0 94 20 95 40 96 59 97 80 99 100 99
Z	70
u	74	 0 102 80 76 100 76
R	70
_	350
_	1
```

So, do so in espeak-ng-mbrola-generic not to stumble on the issue. Adding one trailing space is likely safe enough that it will not start causing issues with future fixed version, and testing showed it doesn't affect the tested version: adding one or more spaces yielded the exact same results for both espeak and espeak-ng with the tested versions.