### PR TITLE
Add Multispeech to prioritization order of modules

### DIFF
--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -705,6 +705,7 @@ static gint modules_compare (gconstpointer a, gconstpointer b)
 		"ibmtts",
 		"festival",
 		"flite",
+		"multispeech",
 		"espeak-ng-mbrola",
 		"espeak-ng-mbrola-generic",
 		"espeak-ng",


### PR DESCRIPTION
[Multispeech](https://github.com/poretsky/multispeech) is a Speech Dispatcher compatible, open source, multilingual speech synthesis system. It can be built yourself, and is also distributed as a [ready-made package](https://poretsky.github.io/packages/) for various distributions, including through the [Debian repository](https://packages.debian.org/search?keywords=multispeech).

Multispeech utilizes third party speech synthesis software to perform actual TTS transformation. Being capable to detect language by text nature it can automatically choose an appropriate TTS for each one. For the moment English, German, French, Italian, Spanish, Portuguese and Russian languages are supported.

Multispeech uses eSpeak and MBROLA technologies, as well as an improved linguistic backend for English MBROLA ([freespeech](https://github.com/poretsky/freespeech)) and [ru_tts](https://github.com/poretsky/ru_tts) synthesizer with a [rulex](https://github.com/poretsky/rulex) dictionary. Therefore, in prioritization order modules to automatically select the best quality, multispeech is logically placed above espeak-ng-mbrola.
