### PR TITLE
Fix comments in mimic3-generic output module

### DIFF
--- a/config/modules/mimic3-generic.conf
+++ b/config/modules/mimic3-generic.conf
@@ -1,4 +1,4 @@
-# The mary-generic output module is based on the generic plugin for Speech
+# The mimic3-generic output module is based on the generic plugin for Speech
 # Dispatcher. It means there is no code written explicitly for
 # this plugin, all the specifics are handled in this configuration
 # and we call a simple command line client to perform the actual
@@ -59,7 +59,7 @@ GenericPunctAll "--punct"
 # AddVoice specifies which $VOICE string should be assigned to
 # each language and symbolic voice name. All the voices you want
 # to use must be specified here. This list will likely not be
-# up-to-date, please check your mary installation and add the voices
+# up-to-date, please check your mimic3 installation and add the voices
 # you want to use.
 
 AddVoice	"af"	"FEMALE1"	"af_ZA/google-nwu_low"


### PR DESCRIPTION
Minor fix to comments accidentally saved from another module taken as a basis.