### PR TITLE
configure: Use AS_HELP_STRING

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,7 @@ AC_SUBST([ERROR_CFLAGS])
 AC_SUBST([RDYNAMIC])
 
 AC_ARG_ENABLE([doc],
-              [AC_HELP_STRING([--disable-doc], [turn off documentation])])
+              [AS_HELP_STRING([--disable-doc], [turn off documentation])])
 AM_CONDITIONAL(ENABLE_DOC, test "$enable_doc" != "no")
 
 # Check for python support.


### PR DESCRIPTION
AC_HELP_STRING has been deprecated for a long time and triggers a warning:

    configure.ac:187: warning: The macro 'AC_HELP_STRING' is obsolete.

https://www.gnu.org/software/autoconf//manual/autoconf-2.69/html_node/Obsolete-Macros.html#Obsolete-Macros

Let’s switch to the modern AS_ variant, we already use it elsewhere in the file.