### PR TITLE
generic: Fix crash

### DIFF
--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -239,7 +239,7 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 	/* TODO: use a generic engine for SPELL, CHAR, KEY */
 	if (msgtype == SPD_MSGTYPE_TEXT)
 	{
-		tmp = module_strip_ssml(tmp);
+		tmp = module_strip_ssml(data);
 		bytes = strlen(tmp);
 	}
 	else


### PR DESCRIPTION
dd759d73f19a ("generic: Fix random garbage on non-text utterances") broke the generic module.