### PR TITLE
generic: Add GenericDefaultCharset parameter

### DIFF
--- a/config/modules/dtk-generic.conf
+++ b/config/modules/dtk-generic.conf
@@ -66,7 +66,7 @@ AddVoice	"en"	"CHILD_MALE"	"k"
 
 defaultVoice    "p"
 
-GenericLanguage	"en" "en"
+GenericDefaultCharset "iso-8859-1"
 
 # These parameters set _rate_ and _pitch_ conversion. This is
 # part of the core of the definition of this generic output

--- a/config/modules/epos-generic.conf
+++ b/config/modules/epos-generic.conf
@@ -53,11 +53,13 @@ defaultVoice    "kadlec"
 # which string to use instead. If you wish to use
 # other than ISO charset for the specified language,
 # you can add it's name (as accepted by iconv) as a
-# third parameter in doublequotes.
+# third parameter in doublequotes, or use GenericDefaultCharset
+# to specify it
 
-GenericLanguage	"cs" "czech" "iso-8859-2"
-GenericLanguage "sk" "slovak" "iso-8859-2"
+GenericLanguage	"cs" "czech"
+GenericLanguage "sk" "slovak"
 
+GenericDefaultCharset "iso-8859-2"
 
 # These parameters set _rate_ and _pitch_ conversion. This is
 # part of the core of the definition of this generic output

--- a/config/modules/espeak-mbrola-generic.conf
+++ b/config/modules/espeak-mbrola-generic.conf
@@ -50,38 +50,13 @@ GenericPunctAll "--punct"
 # which string to use instead. If you wish to use
 # other than ISO charset for the specified language,
 # you can add it's name (as accepted by iconv) as a
-# third parameter in doublequotes.
+# third parameter in doublequotes, or use GenericDefaultCharset
+# to specify it
 
 
-GenericLanguage		  "af" "af" "utf-8"
-GenericLanguage		  "cs" "cs" "utf-8"
-GenericLanguage		  "de" "de" "utf-8"
-GenericLanguage		  "el" "el" "utf-8"
-GenericLanguage		  "en" "en-us" "utf-8"
-GenericLanguage		  "en-gb" "en-gb" "utf-8"
-GenericLanguage		  "en-us" "en-us" "utf-8"
-GenericLanguage		  "es" "es" "utf-8"
-GenericLanguage		  "es-mx" "es-mx" "utf-8"
-GenericLanguage		  "es-ve" "es-ve" "utf-8"
-GenericLanguage		  "et" "et" "utf-8"
-GenericLanguage		  "fa" "fa" "utf-8"
-GenericLanguage		  "fr" "fr" "utf-8"
-GenericLanguage		  "fr-ca" "fr-ca" "utf-8"
-GenericLanguage		  "fr-be" "fr-be" "utf-8"
-GenericLanguage		  "hu" "hu" "utf-8"
-GenericLanguage		  "hr" "hr" "utf-8"
-GenericLanguage		  "id" "id" "utf-8"
-GenericLanguage		  "is" "is" "utf-8"
-GenericLanguage		  "it" "it" "utf-8"
-GenericLanguage		  "la" "la" "utf-8"
-GenericLanguage		  "lt" "lt" "utf-8"
-GenericLanguage		  "nl" "nl" "utf-8"
-GenericLanguage		  "pl" "pl" "utf-8"
-GenericLanguage		  "pt" "pt" "utf-8"
-GenericLanguage		  "pt-br" "pt-br" "utf-8"
-GenericLanguage		  "ro" "ro" "utf-8"
-GenericLanguage		  "sv" "sv" "utf-8"
-GenericLanguage		  "tr" "tr" "utf-8"
+GenericLanguage		  "en" "en-us"
+
+GenericDefaultCharset "utf-8"
 
 # Each voice is available if and only if the following files exist.
 # These files must be listed *before* the voices.
@@ -216,7 +191,7 @@ GenericVolumeForceInteger   0
 
 # Copyright (C) 2008-2010 Brailcom, o.p.s
 # Copyright (C) 2014 Luke Yelavich <themuso@ubuntu.com>
-# Copyright (C) 2018-2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2018-2021, 2025 Samuel Thibault <samuel.thibault@ens-lyon.org>
 # Copyright (C) 2018 Didier Spaier <didier@slint.fr>
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/config/modules/espeak-ng-mbrola-generic.conf
+++ b/config/modules/espeak-ng-mbrola-generic.conf
@@ -56,38 +56,12 @@ GenericPunctAll "--punct"
 # which string to use instead. If you wish to use
 # other than ISO charset for the specified language,
 # you can add it's name (as accepted by iconv) as a
-# third parameter in doublequotes.
+# third parameter in doublequotes, or use GenericDefaultCharset
+# to specify it
 
-# To be completed
-GenericLanguage		  "af" "af" "utf-8"
-GenericLanguage		  "cs" "cs" "utf-8"
-GenericLanguage		  "de" "de" "utf-8"
-GenericLanguage		  "el" "el" "utf-8"
-GenericLanguage		  "en" "en-us" "utf-8"
-GenericLanguage		  "en-gb" "en-gb" "utf-8"
-GenericLanguage		  "en-us" "en-us" "utf-8"
-GenericLanguage		  "es" "es" "utf-8"
-GenericLanguage		  "es-mx" "es-mx" "utf-8"
-GenericLanguage		  "es-ve" "es-ve" "utf-8"
-GenericLanguage		  "et" "et" "utf-8"
-GenericLanguage		  "fa" "fa" "utf-8"
-GenericLanguage		  "fr" "fr" "utf-8"
-GenericLanguage		  "fr-ca" "fr-ca" "utf-8"
-GenericLanguage		  "fr-be" "fr-be" "utf-8"
-GenericLanguage		  "hu" "hu" "utf-8"
-GenericLanguage		  "hr" "hr" "utf-8"
-GenericLanguage		  "id" "id" "utf-8"
-GenericLanguage		  "is" "is" "utf-8"
-GenericLanguage		  "it" "it" "utf-8"
-GenericLanguage		  "la" "la" "utf-8"
-GenericLanguage		  "lt" "lt" "utf-8"
-GenericLanguage		  "nl" "nl" "utf-8"
-GenericLanguage		  "pl" "pl" "utf-8"
-GenericLanguage		  "pt" "pt" "utf-8"
-GenericLanguage		  "pt-br" "pt-br" "utf-8"
-GenericLanguage		  "ro" "ro" "utf-8"
-GenericLanguage		  "sv" "sv" "utf-8"
-GenericLanguage		  "tr" "tr" "utf-8"
+GenericLanguage		  "en" "en-us"
+
+GenericDefaultCharset "utf-8"
 
 # Each voice is available if and only if the following files exist.
 # These files must be listed *before* the voices.
@@ -270,7 +244,7 @@ GenericVolumeForceInteger   0
 
 # Copyright (C) 2008-2010 Brailcom, o.p.s
 # Copyright (C) 2014 Luke Yelavich <themuso@ubuntu.com>
-# Copyright (C) 2018-2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2018-2021, 2025 Samuel Thibault <samuel.thibault@ens-lyon.org>
 # Copyright (C) 2018 Didier Spaier <didier@slint.fr>
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/config/modules/llia_phon-generic.conf
+++ b/config/modules/llia_phon-generic.conf
@@ -46,7 +46,7 @@ AddVoice        "fr"	"male2"      "phoneme-file"
 
 DefaultVoice    "phoneme-file"
 
-GenericLanguage "fr" "fr"
+GenericDefaultCharset "iso-8859-1"
 
 # These parameters set _rate_ and _pitch_ conversion. This is
 # part of the core of the definition of this generic output

--- a/config/modules/mary-generic.conf
+++ b/config/modules/mary-generic.conf
@@ -52,15 +52,13 @@ GenericPunctAll "--punct"
 # which string to use instead. If you wish to use
 # other than ISO charset for the specified language,
 # you can add it's name (as accepted by iconv) as a
-# third parameter in doublequotes.
+# third parameter in doublequotes, or use GenericDefaultCharset
+# to specify it
 
 GenericLanguage  "en" "en_GB" "utf-8"
 GenericLanguage  "en" "en_US" "utf-8"
-GenericLanguage  "de" "de"    "utf-8"
-GenericLanguage  "fr" "fr"    "utf-8"
-GenericLanguage  "tr" "tr"    "utf-8"
-GenericLanguage  "te" "te"    "utf-8"
-GenericLanguage  "it" "it"    "utf-8"
+
+GenericDefaultCharset "utf-8"
 
 # AddVoice specifies which $VOICE string should be assigned to
 # each language and symbolic voice name. All the voices you want

--- a/config/modules/mimic3-generic.conf
+++ b/config/modules/mimic3-generic.conf
@@ -51,10 +51,12 @@ GenericPunctAll "--punct"
 # which string to use instead. If you wish to use
 # other than ISO charset for the specified language,
 # you can add it's name (as accepted by iconv) as a
-# third parameter in doublequotes.
+# third parameter in doublequotes, or use GenericDefaultCharset
+# to specify it
 
 #GenericLanguage  "en" "en_GB" "utf-8"
 #GenericLanguage  "en" "en_US" "utf-8"
+#GenericDefaultCharset "utf-8"
 
 # AddVoice specifies which $VOICE string should be assigned to
 # each language and symbolic voice name. All the voices you want
@@ -109,7 +111,7 @@ AddVoice	"to"	"MALE1"		"yo/openbible_low"
 DefaultVoice    "en_UK/apope_low"
 
 # Copyright (C) 2018 Florian Steinhardt <no.known.email@example.com>
-# Copyright (C) 2022 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2022, 2025 Samuel Thibault <samuel.thibault@ens-lyon.org>
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software

--- a/config/modules/swift-generic.conf
+++ b/config/modules/swift-generic.conf
@@ -53,7 +53,7 @@ AddVoice	"en"	"FEMALE3"	"Callie"
 
 DefaultVoice    "David"
 
-GenericLanguage "en" "en"
+GenericDefaultCharset "iso-8859-1"
 
 # These parameters set _rate_ and _pitch_ conversion. This is
 # part of the core of the definition of this generic output

--- a/doc/speech-dispatcher.html
+++ b/doc/speech-dispatcher.html
@@ -1211,12 +1211,23 @@ The desired rate or speed (a float number defined in GenericRateAdd and GenericR
 </p></dd></dl>
 
 <dl class="first-defvr">
+<dt class="defvr" id="index-GenericDefaultCharset"><span class="category-def">GenericModuleConfiguration: </span><span><strong class="def-name">GenericDefaultCharset</strong> <var class="def-var-arguments">&quot;character-set&quot;</var><a class="copiable-link" href="#index-GenericDefaultCharset"> &para;</a></span></dt>
+<dd>
+<p>Defines the default character set in which the text will be passed to the
+module. If unset, it defaults to <code class="code">iso-8859-1</code>.
+</p>
+<div class="example">
+<pre class="example-preformatted">GenericDefaultCharset &quot;iso-8859-2&quot;
+</pre></div>
+</dd></dl>
+
+<dl class="first-defvr">
 <dt class="defvr" id="index-GenericLanguage"><span class="category-def">GenericModuleConfiguration: </span><span><strong class="def-name">GenericLanguage</strong> <var class="def-var-arguments">&quot;iso-code&quot; &quot;string-subst&quot; &quot;character-set&quot;</var><a class="copiable-link" href="#index-GenericLanguage"> &para;</a></span></dt>
 <dd>
 <p>Defines which string <code class="code">string-subst</code> should be substituted for <code class="code">$LANGUAGE</code>
 given an <code class="code">iso-code</code> language code. Optionally, the character set in which
 the text will be passed to the module can be specified. If unset, it will
-default to iso-8859-1.
+default to the <code class="code">GenericDefaultCharset</code> parameter.
 </p>
 <p>Another example from Epos generic:
 </p><div class="example">
@@ -5664,6 +5675,7 @@ Previous: <a href="#GNU-Free-Documentation-License" accesskey="p" rel="prev">GNU
 <tr><td></td><td class="printindex-index-entry"><a href="#index-FDL_002c-GNU-Free-Documentation-License">FDL, GNU Free Documentation License</a></td><td class="printindex-index-section"><a href="#GNU-Free-Documentation-License">GNU Free Documentation License</a></td></tr>
 <tr><td colspan="3"><hr></td></tr>
 <tr><th id="Index-of-Concepts_cp_letter-G">G</th></tr>
+<tr><td></td><td class="printindex-index-entry"><a href="#index-GenericDefaultCharset"><code>GenericDefaultCharset</code></a></td><td class="printindex-index-section"><a href="#Configuration-of-the-Generic-Output-Module">Configuration of the Generic Output Module</a></td></tr>
 <tr><td></td><td class="printindex-index-entry"><a href="#index-GenericExecuteSynth"><code>GenericExecuteSynth</code></a></td><td class="printindex-index-section"><a href="#Configuration-of-the-Generic-Output-Module">Configuration of the Generic Output Module</a></td></tr>
 <tr><td></td><td class="printindex-index-entry"><a href="#index-GenericLanguage"><code>GenericLanguage</code></a></td><td class="printindex-index-section"><a href="#Configuration-of-the-Generic-Output-Module">Configuration of the Generic Output Module</a></td></tr>
 <tr><td></td><td class="printindex-index-entry"><a href="#index-GenericPitchAdd"><code>GenericPitchAdd</code></a></td><td class="printindex-index-section"><a href="#Configuration-of-the-Generic-Output-Module">Configuration of the Generic Output Module</a></td></tr>

--- a/doc/speech-dispatcher.texi
+++ b/doc/speech-dispatcher.texi
@@ -964,12 +964,22 @@ GenericExecuteSynth \
 @xref{AddVoice}.
 @end defvr
 
+@defvr {GenericModuleConfiguration} GenericDefaultCharset "character-set"
+
+Defines the default character set in which the text will be passed to the
+module. If unset, it defaults to @code{iso-8859-1}.
+
+@example
+GenericDefaultCharset "iso-8859-2"
+@end example
+@end defvr
+
 @defvr {GenericModuleConfiguration} GenericLanguage "iso-code" "string-subst" "character-set"
 
 Defines which string @code{string-subst} should be substituted for @code{$LANGUAGE}
 given an @code{iso-code} language code. Optionally, the character set in which
 the text will be passed to the module can be specified. If unset, it will
-default to iso-8859-1.
+default to the @code{GenericDefaultCharset} parameter.
 
 Another example from Epos generic:
 @example

--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -87,6 +87,7 @@ MOD_OPTION_1_STR(GenericExecuteSynth)
     MOD_OPTION_1_STR(GenericPunctAll)
     MOD_OPTION_1_STR(GenericStripPunctChars)
     MOD_OPTION_1_STR(GenericRecodeFallback)
+    MOD_OPTION_1_STR(GenericDefaultCharset)
 
     MOD_OPTION_1_INT(GenericRateAdd)
     MOD_OPTION_1_FLOAT(GenericRateMultiply)
@@ -127,6 +128,7 @@ int module_load(void)
 	MOD_OPTION_1_STR_REG(GenericDelimiters, ".");
 	MOD_OPTION_1_STR_REG(GenericStripPunctChars, "");
 	MOD_OPTION_1_STR_REG(GenericRecodeFallback, "?");
+	MOD_OPTION_1_STR_REG(GenericDefaultCharset, "iso-8859-1");
 
 	MOD_OPTION_1_INT_REG(GenericRateAdd, 0);
 	MOD_OPTION_1_FLOAT_REG(GenericRateMultiply, 1);
@@ -179,7 +181,7 @@ int module_init(char **status_info)
 	generic_msg_language =
 	    (TGenericLanguage *) g_malloc(sizeof(TGenericLanguage));
 	generic_msg_language->code = g_strdup("en-US");
-	generic_msg_language->charset = g_strdup("iso-8859-1");
+	generic_msg_language->charset = g_strdup(GenericDefaultCharset);
 	generic_msg_language->name = g_strdup("english");
 
 	/* For mbtowc to work in locale charset */
@@ -266,9 +268,9 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 			tmp = newtmp;
 		}
 	} else {
-		DBG("Warning: Preferred charset not specified, recoding to iso-8859-1");
+		DBG("Warning: Preferred charset not specified, recoding to %s", GenericDefaultCharset);
 		newtmp =
-		    (char *)g_convert_with_fallback(tmp, bytes, "iso-8859-1",
+		    (char *)g_convert_with_fallback(tmp, bytes, GenericDefaultCharset,
 						    "UTF-8",
 						    GenericRecodeFallback, NULL,
 						    NULL, &gerror);
@@ -769,7 +771,7 @@ void generic_set_language(char *lang)
 		generic_msg_language =
 		    (TGenericLanguage *) g_malloc(sizeof(TGenericLanguage));
 		generic_msg_language->code = g_strdup("en-US");
-		generic_msg_language->charset = g_strdup("iso-8859-1");
+		generic_msg_language->charset = g_strdup(GenericDefaultCharset);
 		generic_msg_language->name = g_strdup("english");
 	}
 


### PR DESCRIPTION
This avoids having to use GenericLanguage just to specify the charset, and keep it only for the original purpose: translate from iso code to synth-specific code.