### PR TITLE
output: Add missing signaling when not reading message any more

### DIFF
--- a/src/server/output.c
+++ b/src/server/output.c
@@ -315,6 +315,7 @@ GString *output_read_reply(OutputModule * output)
 			message = output_read_message(output);
 			pthread_mutex_lock(&output->read_mutex);
 			output->reading_message = FALSE;
+			pthread_cond_signal(&output->reply_cond);
 			if (!message)
 				/* Module broke */
 				break;
@@ -361,6 +362,7 @@ GString *output_read_event(OutputModule * output)
 			message = output_read_message(output);
 			pthread_mutex_lock(&output->read_mutex);
 			output->reading_message = FALSE;
+			pthread_cond_signal(&output->reply_cond);
 			if (!message)
 				/* Module broke */
 				break;


### PR DESCRIPTION
Otherwise this can get stuck when leaving the Orca preference dialog:

6  ___pthread_cond_wait (cond=0x55e35e11fcd0, mutex=0x55e35e11fca8) at ./nptl/pthread_cond_wait.c:458 7  0x000055e340c5a58b in output_read_reply (output=0x55e35e11fc40) at output.c:299 8  0x000055e340c5adae in output_get_voices (output=0x55e35e11fc40, language=0x0, variant=0x0) at output.c:521 9  0x000055e340c5b1dc in output_list_voices (module_name=0x55e35e11cb00 "espeak-ng", language=0x0, variant=0x0) at output.c:601 10 0x000055e340c5228d in parse_list (buf=0x55e35e12bc10 "LIST SYNTHESIS_VOICES\r\n", bytes=23, fd=34, speechd_socket=0x55e35e12cb20) at parse.c:964 11 0x000055e340c4d97f in parse (buf=0x55e35e12bc10 "LIST SYNTHESIS_VOICES\r\n", bytes=23, fd=34) at parse.c:108 12 0x000055e340c478f1 in serve (fd=34) at server.c:269