### PR TITLE
Fix value returned by module_speak

### DIFF
--- a/src/modules/cicero.c
+++ b/src/modules/cicero.c
@@ -281,7 +281,7 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 	sem_post(cicero_semaphore);
 
 	DBG("Cicero: leaving module_speak() normally\n\r");
-	return bytes;
+	return 1;
 }
 
 int module_stop(void)

--- a/src/modules/dummy.c
+++ b/src/modules/dummy.c
@@ -124,7 +124,7 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 	sem_post(dummy_semaphore);
 
 	DBG("Dummy: leaving write() normally\n\r");
-	return bytes;
+	return 1;
 }
 
 int module_stop(void)

--- a/src/modules/generic.c
+++ b/src/modules/generic.c
@@ -295,7 +295,7 @@ int module_speak(gchar * data, size_t bytes, SPDMessageType msgtype)
 	sem_post(generic_semaphore);
 
 	DBG("Generic: leaving write() normally\n\r");
-	return bytes;
+	return 1;
 }
 
 int module_stop(void)


### PR DESCRIPTION
It was never documented as returning the number of bytes. If that happens to be zero, it would wrongly believed to be failing.