### PR TITLE
Remove blank line at THE begiNning of config/speechd.conf

### DIFF
--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -1,4 +1,3 @@
-
 # Global configuration for Speech Dispatcher
 # ==========================================
 


### PR DESCRIPTION
This is the file that gets installed and it is a bit weird when editing
one's configuration file to land on a blank line when opening it.