### PR TITLE
Revert "module_main: make module_stdout_mutex recursive"

### DIFF
--- a/src/modules/module_main.c
+++ b/src/modules/module_main.c
@@ -1,7 +1,7 @@
 /*
  * module_main.c - Main file of output modules.
  *
- * Copyright (C) 2020-2021, 2025 Samuel Thibault <samuel.thibault@ens-lyon.org>
+ * Copyright (C) 2020-2021 Samuel Thibault <samuel.thibault@ens-lyon.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,15 +42,9 @@ int main(int argc, char *argv[])
 	char *configfile = NULL;
 	char *line, *msg = NULL;
 	int ret;
-	pthread_mutexattr_t attr;
 
 	if (argc >= 2)
 		configfile = argv[1];
-
-	/* To make it convenient for some async modules to make some sync calls.  */
-	pthread_mutexattr_init(&attr);
-	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-	pthread_mutex_init(&module_stdout_mutex, &attr);
 
 	/* Read configuration */
 	ret = module_config(configfile);


### PR DESCRIPTION
This reverts commit 3e5c5b7a8da66f79cd7d7f6e4cb631ec2abd1b8d.

We are not actually supposed to call module_report_event_begin/end inside module_speak... Better make the module hang (which is easy to see in gdb) rather than the server hang (which requires understanding that begin/end can only happen after the 200 ack).