### PR TITLE
Fix typo

### DIFF
--- a/config/speechd.conf
+++ b/config/speechd.conf
@@ -205,7 +205,7 @@ SymbolsPreprocFile "orca-math.dic"
 # latency related advantages it has over pulseaudio and others, however enabling
 # it should be done with precaution, because it isn't tested to work in all
 # configurations supported by speech dispatcher.
-# For now, enabling this is at the discression of the users and packagers of
+# For now, enabling this is at the discretion of the users and packagers of
 # speech dispatcher. However, because we want to eventually make this the default
 # for everyone, trying it in your deployments, if non-critical, is recommended
 #


### PR DESCRIPTION
Substitute: "discression" with "discretion".

Reference: https://www.collinsdictionary.com/dictionary/english/discretion