### PR TITLE
Remove REGEX dependency from Common Lisp ASDF:defsystem definition.

### DIFF
--- a/src/api/cl/ssip.asd
+++ b/src/api/cl/ssip.asd
@@ -19,7 +19,7 @@
 (in-package :asdf)
 
 
-(defsystem :ssip :depends-on (:regex #+SBCL :sb-bsd-sockets)
+(defsystem :ssip :depends-on (#+SBCL :sb-bsd-sockets)
   :components
   ((:file "package")
    (:file "sysdep")


### PR DESCRIPTION
The REGEX library is not actually used in this Lisp code, and the REGEX library itself is deprecated, and has not been supported for many years or decades by its author.