### PR TITLE
Fix client connection race

### DIFF
--- a/speech-dispatcher.service.in
+++ b/speech-dispatcher.service.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2018, 2022-2023 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (C) 2018, 2022-2023, 2026 Samuel Thibault <samuel.thibault@ens-lyon.org>
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free Software
@@ -19,5 +19,5 @@ Requires=speech-dispatcher.socket
 
 [Service]
 Type=simple
-ExecStart=@bindir@/speech-dispatcher -s -t 0
+ExecStart=@bindir@/speech-dispatcher -s
 ExecReload=/bin/kill -HUP $MAINPID

--- a/src/server/speechd.c
+++ b/src/server/speechd.c
@@ -107,10 +107,11 @@ static gboolean speechd_client_terminate(gpointer key, gpointer value, gpointer 
 static gboolean speechd_reload_dead_modules(gpointer user_data);
 static gboolean speechd_reload_configuration(gpointer user_data);
 enum quit_reason {
+	QUIT_TIMEOUT,
 	QUIT_SIGINT,
 	QUIT_SIGTERM,
-	QUIT_TIMEOUT,
 };
+static enum quit_reason quit_reason = QUIT_TIMEOUT;
 static gboolean speechd_quit(gpointer user_data);
 
 static gboolean server_process_incoming (gint          fd,
@@ -863,7 +864,11 @@ static void speechd_check_modules(void)
 
 static gboolean speechd_quit(gpointer user_data)
 {
-	switch ((enum quit_reason)(uintptr_t) user_data) {
+	/* Don't drop an existing non-timeout reason.  */
+	if (quit_reason == QUIT_TIMEOUT)
+		quit_reason = (enum quit_reason)(uintptr_t) user_data;
+
+	switch (quit_reason) {
 		case QUIT_SIGINT:
 			MSG(4, "Got SIGINT");
 			break;
@@ -1440,7 +1445,11 @@ int main(int argc, char *argv[])
 
 	check_client_count();
 
-	g_main_loop_run(main_loop);
+	do {
+		g_main_loop_run(main_loop);
+		/* Make a last client check before existing on timeout.
+		 * Systemd will restart us if a client connected in between. */
+	} while (quit_reason == QUIT_TIMEOUT && client_count > 0);
 
 	MSG(1, "Terminating...");
 


### PR DESCRIPTION
To make sure we do not miss a client connection, we need to make sure that we do not exit while a client is connected. We thus have to:

- make sure we have not accepted a client after timeout triggered, i.e. speechd_connection_new was not called. Just dropping the timeout source on client connection is not enough, since "sources that have already been dispatched when g_main_loop_quit is called will still be executed", i.e. after the speechd_quit timeout got called, we may call speechd_connection_new. It's thus the main function that should make a last check against any connected client when the quit reason is a timeout.

- main() then does not call accept, leaving any clients connecting in between waiting on the server socket. On exit, systemd will notice the pending clients, and re-spawn speech-dispatcher.

- this allows to restore the systemd-socket-activation exit on timeout.

Fixes #777
Fixes #1087