### PR TITLE
Honour the log level in the audio backends

### DIFF
--- a/src/audio/alsa.c
+++ b/src/audio/alsa.c
@@ -1,4 +1,3 @@
-
 /*
  * alsa.c -- The Advanced Linux Sound System backend for Speech Dispatcher
  *
@@ -85,7 +84,7 @@ static int wait_for_poll(spd_alsa_id_t * id, struct pollfd *alsa_poll_fds,
 #endif
 
 /* Put a message into the logfile (stderr) */
-#define MSG(level, arg, ...) if (level <= alsa_log_level) { MSG(0, "ALSA: " arg, ##__VA_ARGS__); }
+#define MSG(level, arg, ...) if (level <= alsa_log_level) { MSG(level, "ALSA: " arg, ##__VA_ARGS__); }
 #define ERR(arg, ...) MSG(0, "ALSA ERROR: " arg, ##__VA_ARGS__)
 
 static int alsa_log_level;

--- a/src/audio/libao.c
+++ b/src/audio/libao.c
@@ -45,7 +45,7 @@
 #define AO_SEND_BYTES 256
 
 /* Put a message into the logfile (stderr) */
-#define MSG(level, arg, ...) if (level <= libao_log_level) { MSG(0, "libao: " arg, ##__VA_ARGS__); }
+#define MSG(level, arg, ...) if (level <= libao_log_level) { MSG(level, "libao: " arg, ##__VA_ARGS__); }
 #define ERR(arg, ...) MSG(0, "libao ERROR: " arg, ##__VA_ARGS__)
 
 /* AO_FORMAT_INITIALIZER is an ao_sample_format structure with zero values

--- a/src/audio/nas.c
+++ b/src/audio/nas.c
@@ -42,7 +42,7 @@
 #include "../common/common.h"
 
 /* Put a message into the logfile (stderr) */
-#define MSG(level, arg, ...) if (level <= nas_log_level) { MSG(0, "nas: " arg, ##__VA_ARGS__); }
+#define MSG(level, arg, ...) if (level <= nas_log_level) { MSG(level, "nas: " arg, ##__VA_ARGS__); }
 #define ERR(arg, ...) MSG(0, "nas ERROR: " arg, ##__VA_ARGS__)
 
 typedef struct {

--- a/src/audio/oss.c
+++ b/src/audio/oss.c
@@ -1,4 +1,3 @@
-
 /*
  * oss.c -- The Open Sound System backend for the spd_audio library.
  *
@@ -62,7 +61,7 @@ static int _oss_close(spd_oss_id_t * id);
 static int _oss_sync(spd_oss_id_t * id);
 
 /* Put a message into the logfile (stderr) */
-#define MSG(level, arg, ...) if (level <= oss_log_level) { MSG(0, "OSS: " arg, ##__VA_ARGS__); }
+#define MSG(level, arg, ...) if (level <= oss_log_level) { MSG(level, "OSS: " arg, ##__VA_ARGS__); }
 #define ERR(arg, ...) MSG(0, "OSS ERROR: " arg, ##__VA_ARGS__)
 
 static int oss_log_level;

--- a/src/audio/pipewire.c
+++ b/src/audio/pipewire.c
@@ -56,7 +56,7 @@ static int32_t pipewire_log_level; // only one per module, accessing this from m
 do {                                             \
     if (level <= pipewire_log_level)             \
     {                                            \
-        MSG(0, "pipewire: " arg, ##__VA_ARGS__); \
+        MSG(level, "pipewire: " arg, ##__VA_ARGS__); \
     }                                            \
 } while (0)
 #define error(arg, ...) message(0, "pipewire: fatal: " arg, ##__VA_ARGS__)

--- a/src/audio/pulse.c
+++ b/src/audio/pulse.c
@@ -1,4 +1,3 @@
-
 /*
  * pulse.c -- The simple pulseaudio backend for the spd_audio library.
  *
@@ -88,7 +87,7 @@ static int pulse_log_level;
 static char const *pulse_play_cmd = "paplay -n speech-dispatcher-generic";
 
 /* Put a message into the logfile (stderr) */
-#define MSG(level, arg, ...) if (level <= pulse_log_level) { MSG(0, "Pulse: " arg, ##__VA_ARGS__); }
+#define MSG(level, arg, ...) if (level <= pulse_log_level) { MSG(level, "Pulse: " arg, ##__VA_ARGS__); }
 #define ERR(arg, ...) MSG(0, "Pulse ERROR: " arg, ##__VA_ARGS__)
 
 /* The following is a copy of pulseaudio's src/pulse/simple.c


### PR DESCRIPTION
Although the backends did test for the value of level in
their logging macros, they did not actually pass it to the generic
MSG logging macro.